### PR TITLE
增加中考词汇 markdown 文档

### DIFF
--- a/中考英语词汇表.md
+++ b/中考英语词汇表.md
@@ -1,0 +1,1902 @@
+﻿单词                            | 音标                                 | 译文
+:------------------------------|:-------------------------------------|:----------------------------------------
+a (an)                         | [ə, eɪ(ən)]                          | art. 一（个、件……）
+ability                        | [əˈbɪlɪtɪ]                           | n. 能力;才能
+able                           | [ˈeɪb(ə)l]                           | a. 能够;有能力的
+about                          | [əˈbaʊt]                             | ad. 大约;到处;四处 prep. 关于;在各处;四处
+above                          | [əˈbʌv]                              | prep. 在…上面 a. 上面的 ad. 在…之上
+abroad                         | [əˈbrɔːd]                            | ad. 到（在）国外
+accept                         | [əkˈsept]                            | vt. 接受
+accident                       | [ˈæksɪdənt]                          | n. 事故,意外
+across                         | [əˈkrɔs]                             | prep./ad. 横过;穿过;另一边,在对面
+act                            | [ækt]                                | n. 法令，条例 v. 行动,（戏）表演,扮演（角色）
+action                         | [ˈækʃ(ə)n]                           | n. 行动,行为,举动
+active                         | [ˈæktɪv]                             | a. 积极的，主动的
+activity                       | [ækˈtɪvɪtɪ]                          | n. 活动
+advantage                      | [ədˈvɑːntɪdʒ]                        | n. 优点；好处,有利条件
+advertisement                  | [ədˈvɜːtɪsmənt]                      | n. 广告
+advice                         | [ədˈvaɪs]                            | n. 忠告，劝告，建议
+afford                         | [əˈfɔːd]                             | vt. 负担得起（…的费用）；抽得出（时间）；提供
+afraid                         | [əˈfreɪd]                            | a. 害怕的；担心
+Africa                         | [ˈæfrɪkə]                            | n. 非洲
+after                          | [ˈɑːftə(r)]                          | ad. 在后；后来 prep. 在…之后 conj. 在…以后
+afternoon                      | [ɑːftəˈnuːn]                         | n. 下午，午后
+again                          | [əˈɡeɪn]                             | ad. 再一次；再，又
+against                        | [əˈɡeɪnst]                           | prep. 对着,反对,倚靠
+age                            | [eɪdʒ]                               | n. 年龄；时代
+ago                            | [əˈɡəʊ]                              | ad. 以前
+agree                          | [əˈɡriː]                             | v. 同意
+air                            | [eə(r)]                              | n. 空气；大气
+aircraft                       | [ˈeəkrɑːft]                          | n. 飞机 (单复数同)
+airline                        | [ ˈeəlain]                           | n. 航空公司;航空系统;航线
+airplane                       | [ˈeəpleɪn]                           | n. （美）飞机
+airport                        | [ˈeəpɔːt]                            | n. 航空站,飞机场
+alike                          | [əˈlaɪk]                             | ad. 很相似地，同样地
+alive                          | [əˈlaɪv]                             | a. 活着的，存在的
+all                            | [ɔːl]                                | ad. 全部地 a. 全（部）;所有的;总;整 pron. 全部;全体
+allow                          | [əˈlaʊ]                              | vt. 允许，准许
+almost                         | [ˈɔːlməʊst]                          | ad. 几乎，差不多
+alone                          | [əˈləʊn]                             | a. 单独的，孤独的
+along                          | [əˈlɔŋ; (US) əˈlɔŋ]                  | ad. 向前；和…一起；一同 prep. 沿着；顺着
+already                        | [ɔːlˈredɪ]                           | ad. 已经
+also                           | [ˈɔːlsəʊ]                            | ad. 也
+although                       | [ɔːlˈðəʊ]                            | conj. 虽然，尽管
+always                         | [ˈɔːlweɪz]                           | ad. 总是；一直；永远
+am/æm/                         |                                      | v. be的人称形式之一
+a.m./A.M.                      |                                      | n. 午前，上午
+amaze                          | [əˈmeɪz]                             | v. 惊奇，惊叹；震惊
+amazing                        | [əˈmeɪzɪŋ]                           | a. 惊叹的;震惊的;令人惊讶的
+America                        | [əˈmerɪkə]                           | n. 美国；美洲
+American                       | [əˈmerɪkən]                          | a. 美国的；美国人的 n. 美国人
+among                          | [əˈmʌŋ]                              | prep. 在…中间；在（三个以上）之间
+and                            | [ənd, ænd]                           | conj. 和；又
+angel                          | [ˈeindʒəl]                           | n. 天使,守护神
+angry                          | [ˈænɡrɪ]                             | a. 生气的，愤怒的
+animal                         | [ˈænɪm(ə)l]                          | n. 动物
+another                        | [əˈnʌðə(r)]                          | a. 再一；另一；别的 pron. 另一个
+answer                         | [ˈɑːnsə(r); (US) ˈænsər]             | n. 回答,答复;答案 v. 回答,答复;（作出）答案
+any                            | [ˈenɪ]                               | pron. 任何的;（用于疑问句、否定句）一些；什么
+anyhow                         | [ˈenɪhaʊ]                            | ad. 不管怎样
+anyone                         | [ˈenɪwʌn]                            | pron. 任何人，无论谁
+anything                       | [ˈenɪθɪŋ]                            | pron. 什么事（物）；任何事（物）
+anywhere                       | [ˈenɪweə(r)]                         | ad. 任何地方
+apologize                      | [əˈpɔlədʒaɪz]                        | vi. 道歉，谢罪
+apology                        | [əˈpɔlədʒɪ]                          | n. 道歉；歉意
+apple                          | [ˈæp(ə)l]                            | n. 苹果
+April                          | [ˈeɪpr(ə)l]                          | n. 4月
+Arab                           | [ˈærəb]                              | a. 阿拉伯的 n. 阿拉伯人
+area                           | [ˈeərɪə]                             | n. 面积；地域，区域；范围，领域
+arm                            | [ɑːm]                                | n. 臂,支架,（美）武器,武力
+army                           | [ˈɑːmɪ]                              | n. 军队
+around                         | [əˈraʊnd]                            | ad. 在周围；在附近 prep. 在…周围；大约
+arrive                         | [əˈraɪv]                             | vi. 到达；达到
+arrow                          | [ˈærəʊ]                              | n. 箭；箭头
+art                            | [ɑːt]                                | n. 艺术，美术；技艺
+artist                         | [ˈɑːtɪst]                            | n. 艺术家,美术家
+article                        | [ˈɑːtɪk(ə)l]                         | n. 文章;物品;冠词
+as                             | [əz, æz]                             | ad.& conj. 像…一样;当…时；如同；因为 prep. 作为，当做
+Asia                           | [ˈeɪʃə]                              | n. 亚洲
+Asian                          | [ˈeɪʃ(ə)n, ˈeɪʒ(ə)n]                 | a. 亚洲（人）的 n. 亚洲人
+ask                            | [ɑːsk]                               | v. 问；请求，要求；邀请
+asleep                         | [əˈsliːp]                            | a. 睡着的，熟睡
+assistant                      | [əˈsɪst(ə)nt]                        | n. 助手，助理
+at                             | [æt]                                 | prep. 在（几点钟）;在（某处）
+attack                         | [əˈtæk]                              | vt. / n. 攻击，袭击
+attend                         | [əˈtend]                             | v. 看护，照料，服侍；出席，参加
+attention                      | [əˈtenʃ(ə)n]                         | n. 注意，关心
+attract                        | [əˈtrækt]                            | v. 吸引，引起
+August                         | [ˈɔːɡəst]                            | n. 8月
+aunt                           | [ɑːnt; (US) ænt]                     | n. 伯母；舅母；婶；姑；姨
+Australia                      | [ɔˈstreɪljə]                         | n. 澳洲；澳大利亚
+Australian                     | [ɔˈstreɪlɪən]                        | a. 澳洲的，澳大利亚人的 n. 澳大利亚人
+autumn                         | [ˈɔːtəm]                             | n. 秋天，秋季
+awake (awoke, awoken)          | [əˈweɪk]                             | v. 唤醒 a. 醒着的
+away                           | [əˈweɪ]                              | ad. 离开；远离
+awful                          | [ɔːfu:l]                             | adj.极坏的、极讨厌的、糟糕的、可怕的
+baby                           | [ˈbeɪbɪ]                             | n. 婴儿
+back                           | [bæk]                                | ad. 回（原处）；向后 a. 后面的 n. 背后，后部；背
+bad (worse, worst)             | [bæd]                                | a. 坏的；有害的，不利的；严重的
+badly                          | [ˈbædlɪ]                             | ad. 坏，恶劣地
+bake                           | [beɪk]                               | v. 烤； 烘（面包）
+ball                           | [bɔːl]                               | n. 球 n. 舞会
+balloon                        | [bəˈluːn]                            | n. 气球
+bamboo                         | [bæmˈbuː]                            | n. 竹子
+banana                         | [bəˈnɑːnə; (US) bəˈnænə]             | n. 香蕉
+band                           | [bænd]                               | n. 乐队,波段,一伙,一帮,带(状物)
+bang                           | [bæŋ]                                | int. 砰
+bank                           | [bæŋk]                               | n.（河海湖的）岸，堤, 银行
+base                           | [beɪs]                               | n. 根据地,基地,（棒球）垒
+baseball                       | [ˈbeɪsbɔːl]                          | n. 棒球
+basket                         | [ˈbɑːskɪt; (US) ˈbæskɪt]             | n. 篮子
+basketball                     | [ˈbɑːskɪtbɔːl]                       | n. 篮球
+bath                           | [bɑːθ; (US) bæθ]                     | n. 洗澡；浴室；澡盆
+be                             | [biː]                                | v. 是 (am, is, are, was, were, being, been)；成为
+beach                          | [biːtʃ]                              | n. 海滨，海滩
+bear                           | [beə(r)]                             | v. 承受，负担，承担；忍受；容忍 n. 熊
+beat (beat, beaten)            | [biːt]                               | v. 敲打；跳动；打赢 n.（音乐）节拍
+beautiful                      | [ˈbjuːtɪf(ə)l]                       | a. 美，美丽，美观的
+because                        | [bɪˈkɔz; (US) bɪˈkɔːz]               | conj. 因为
+become (became, be come)       | [bɪˈkʌm]                             | v. 变得；成为
+bed                            | [bed]                                | n. 床
+bedroom                        | [ˈbedruːm]                           | n. 寝室，卧室
+bee                            | [biː]                                | n. 蜜蜂
+beef                           | [biːf]                               | n. 牛肉
+beer                           | [bɪə(r)]                             | n. 啤酒
+before                         | [bɪˈfɔː(r)]                          | prep. 在…以前；在…前面 ad. 以前 conj. 在…之前
+beg                            | [beɡ]                                | v. 请求，乞求，乞讨 
+begin(began,begun)             | [bɪˈɡɪn]                             | v. 开始,着手
+beginning                      | [bɪˈɡɪnɪŋ]                           | n. 开始，开端
+behind                         | [bɪˈhaɪnd]                           | prep. (表示位置)在…后面 ad. 在后面；向后
+believe                        | [bɪˈliːv]                            | v. 相信，认为
+bell                           | [bel]                                | n. 钟,铃;钟(铃)声;钟形物
+below                          | [bɪˈləʊ]                             | prep. 在…下面
+beside                         | [bɪˈsaɪd]                            | prep. 在…旁边；靠近
+besides                        | [bɪˈsaɪdz]                           | prep. 除…以外（还有） ad. 还有，此外
+best（good, well的最高级）     | [best]                               | a. & ad. 最好的,最好地,最 n. 最好的（人或物）
+best-seller                    | [best- ˈselə(r)]                     | n. 畅销书
+better (good, well的比较级)    | [ˈbetə(r)]                           | a.& ad. 更好的,更好地；更,更多 n. 较好的事物
+between                        | [bɪˈtwiːn]                           | prep. 在（两者）之间；在…中间
+bicycle                        | [ˈbaɪsɪk(ə)l]                        | n. 自行车
+big                            | [bɪɡ]                                | a. 大的
+bike = bicycle                 | [baɪk]                               | n. 自行车
+bill                           | [bɪl]                                | n.账单；法案，议案；（美）钞票，纸币
+billion                        | [ˈbɪljən]                            | num. 十亿
+biology                        | [baiɔlədʒɪ]                          | n. 生物（学）
+bird                           | [bəːd]                               | n. 鸟
+birth                          | [bəːθ]                               | n. 出生；诞生
+birthday                       | [ˈbəːθdeɪ]                           | n. 生日
+bit                            | [bɪt]                                | n. 一点，一些，少量的
+black                          | [blæk]                               | n. 黑色 a. 黑色的
+blackboard                     | [ˈblækbɔːd]                          | n. 黑板
+blank                          | [blæŋk]                              | n.& a. 空格，空白（处）；空的；茫然无表情的
+blind                          | [blaɪnd]                             | a. 瞎的
+blouse                         | [blaʊz; U.S. blaʊs]                  | n. 宽罩衫；（妇女、儿童穿的）短上衣
+blow (blew, blown)             | [bləʊ]                               | v. 吹；刮风；吹气 n. 击；打击
+blue                           | [bluː]                               | n. 蓝色 a. 蓝色的 a. 悲伤的；沮丧的
+board                          | [bɔːd]                               | n. 木板；布告牌;（政府的）部 v. 上（船、火车、飞机）
+boat                           | [bəʊt]                               | n. 小船，小舟
+boating                        | [ˈbəʊtɪŋ]                            | n. 划船（游玩），泛舟
+body                           | [bɔːdi]                              | n. 身体
+book                           | [bʊk]                                | n. 书；本子 v. 预定，定（房间、车票等）
+bookmark                       | [ˈbʊkmɑːk]                           | n. 书签
+bookshop                       | [ˈbʊkʃɔp]                            | n.书店
+bookstore                      | [ˈbʊkstɔː(r)]                        | n. 书店
+boom                           | [buːm]                               | n. / v. 繁荣，轰鸣，激增
+boot                           | [buːt]                               | n. 长筒靴；靴
+boring                         | [`bɔrɪŋ]                             | a. 乏味的，无聊的
+born                           | [bɔːn]                               | a. 出生的
+borrow                         | [ˈbɔrəʊ]                             | v.（向别人）借用；借
+both                           | [bəʊθ]                               | a. 两；双 pron. 两者；双方
+bottle                         | [ˈbɔt(ə)l]                           | n. 瓶子
+bottom                         | [ˈbɔtəm]                             | n. 底部；底
+bowl                           | [bəʊl]                               | n. 碗
+box                            | [bɔks]                               | n. 盒子，箱子
+boy                            | [bɔɪ]                                | n. 男孩
+brain                          | [breɪn]                              | n. 脑（子）
+bread                          | [bred]                               | n. 面包
+break (broke, broken)          | [breɪk]                              | n. 间隙,中断,暂停 v. 打破（断，碎）
+breakfast                      | [ˈbrekfəst]                          | n. 早餐
+breathe                        | [briːð]                              | vi. 呼吸
+bridge                         | [brɪdʒ]                              | n. 桥
+bright                         | [braɪt]                              | a. 明亮的；聪明的
+bring (brought, brought)       | [brɪŋ]                               | vt. 拿来，带来，取来
+Britain                        | [ˈbrɪtən]                            | n. 英国；不列颠
+British                        | [ˈbrɪtɪʃ]                            | a. 英国的；大不列颠的；英国人的
+broadcast                      | [ˈbrɔːdkɑːst]                        | n. /v. 广播
+broken                         | [ˈbrəʊkən]                           | a. 弄坏了的
+broom                          | [bruːm]                              | n. 扫帚
+brother                        | [ˈbrʌðə(r)]                          | n. 兄；弟
+brotherhood                    | [ˈbrʌðəhʊd]                          | n. 兄弟般的关系
+brown                          | [braʊn]                              | n. 褐色，棕色 a. 褐色的，棕色的
+brush                          | [brʌʃ]                               | v. 刷；擦 n. 刷子
+build (built, built)           | [bɪld]                               | v. 建筑；造
+building                       | [ˈbɪldɪŋ]                            | n. 建筑物；房屋；大楼
+burn (-ed, -ed / burnt, burnt) | [bɜːn]                               | v. 燃烧,着火;使烧焦;使晒黑 n. 烧伤;晒伤
+bury                           | [ˈberɪ]                              | vt. 埋；葬
+bus                            | [bʌs]                                | n. 公共汽车
+business                       | [ˈbɪznɪs]                            | n.（本分）工作，职业；职责；生意，交易；事业
+businessman (pl. businessmen)  | [ˈbɪznɪsmæn]                         | n. 商人（男）；男企业家
+busy                           | [ˈbɪzɪ]                              | a. 忙（碌）的
+but                            | [bət, bʌt]                           | conj. 但是，可是 prep. 除了, 除……外
+butter                         | [ˈbʌtə(r)]                           | n. 黄油，奶油
+butterfly                      | [ˈbʌtəflaɪ]                          | n. 蝴蝶
+button                         | [ˈbʌt(ə)n]                           | n. 纽扣；（电铃等的）按钮 v. 扣（纽扣） 
+buy (bought,bought)            | [baɪ]                                | vt. 买
+by                             | [baɪ]                                | prep. 在…旁；不迟于；被；用；乘（车）
+bye                            | [ˈbaɪbaɪ]                            | int. 再见
+cabbage                        | [ˈkæbɪdʒ]                            | n. 卷心菜，洋白菜
+café                           | [ˈkæfeɪ; (US) kæˈfeɪ]                | n. 咖啡馆;餐馆
+cage                           | [keɪdʒ]                              | n 笼；鸟笼
+cake                           | [keɪk]                               | n. 蛋糕，糕点；饼
+call                           | [kɔːl]                               | n. 喊，叫；电话，通话 v. 称呼；呼唤；喊，叫
+camel                          | [ˈkæm(ə)l]                           | n. 骆驼
+camera                         | [ˈkæmərə]                            | n. 照相机；摄像机
+camp                           | [kæmp]                               | n.（夏令）营 vi. 野营,宿营
+can (could)                    | [ken, kæn]                           | v. 可能；能够；可以 n.（美）罐头；罐子
+Canada                         | [ˈkænədə]                            | n. 加拿大
+Canadian                       | [kəˈneɪdɪən]                         | a. 加拿大的；加拿大人的 n. 加拿大人
+cancer                         | [ˈkænsə]                             | n. 癌,癌症,弊端,社会恶习
+candle                         | [ˈkænd(ə)l]                          | n. 蜡烛
+candy                          | [ˈkændɪ]                             | n. 糖果
+cannon                         | [kænən]                              | n. 大炮
+canoe                          | [kəˈnuː]                             | n. 独木舟 v. 乘独木舟
+cap                            | [kæp]                                | n. 帽子；（瓶子的）盖
+capital                        | [ˈkæpɪt(ə)l]                         | n.首都,省会,大写；资本
+captain                        | [ˈkæptɪn]                            | n.（海军）上校；船长，舰长；队长
+caption                        | [ˈkæpʃ(ə)n]                          | n.（图片，漫画等的）说明文字
+car                            | [kɑː(r)]                             | n. 汽车，小卧车
+card                           | [kɑːd]                               | n.卡片；名片；纸牌
+care                           | [keə(r)]                             | n. 照料，保护；小心 v. 介意…，在乎；关心
+careful                        | [ˈkeəfʊl]                            | a. 小心，仔细，谨慎的
+careless                       | [ˈkeəlɪs]                            | a. 粗心的，漫不经心的
+carrot                         | [ˈkærət]                             | n. 胡萝卜
+carry                          | [ˈkærɪ]                              | vt. 拿，搬，带，提，抬，背，抱，运等
+cat                            | [kæt]                                | n. 猫
+catch(caught,caught)           | [kætʃ]                               | v. 接住；捉住；赶上；染上（疾病）
+cause                          | [kɔːz]                               | n. 原因，起因 vt. 促使，引起，使发生
+CD                             | [ˌsi:'di:]                           | 光盘 (compact disk的缩写)
+ceiling                        | [ˈsiːlɪŋ]                            | n. 天花板，顶棚
+celebrate                      | [ˈselɪbreɪt]                         | v. 庆祝
+celebration                    | [selɪˈbreɪʃ(ə)n]                     | n. 庆祝；庆祝会
+cent                           | [sent]                               | n. 美分（100 cents = 1 dollar）
+centre (美 center )            | [ˈsentə]                             | n. 中心，中央
+century                        | [ˈsentʃurɪ]                          | n. 世纪，百年
+certain                        | [ˈsɜːt(ə)n]                          | a. （未指明真实名称的）某…；确定的，无疑的；一定会…
+certainly                      | [ˈsɜːtənlɪ]                          | ad. 当然；一定，无疑
+chair                          | [tʃeə(r)]                            | n. 椅子
+chalk                          | [tʃɔːk]                              | n. 粉笔
+challenge                      | [ˈtʃælɪndʒ]                          | n.挑战(性)
+chance                         | [tʃɑːns; (US) tʃæns]                 | n. 机会，可能性
+change                         | [tʃeɪndʒ]                            | n. 零钱；找头 v. 改变，变化；更换；兑换
+channel                        | [ˈtʃæn(ə)l]                          | n.频道；通道；水渠
+chart                          | [tʃɑːt]                              | n. 图表；航海图
+cheap                          | [tʃiːp]                              | a. 便宜的，贱
+check                          | [tʃek]                               | n. 检查；批改 vt. 校对，核对；检查；批改
+check-out                      | [tʃekaut]                            | n. 结账台,收银台
+cheese                         | [tʃiːz]                              | n. 奶酪
+chemistry                      | [ˈkemistri]                          | n. 化学
+cheque                         | [tʃek]                               | (美check) n. 支票
+chess                          | [tʃes]                               | n. 国际象棋,棋
+chick                          | [tʃɪk]                               | n. 小鸡
+chicken                        | [ˈtʃɪkən]                            | n. 鸡；鸡肉
+child (复children)             | [tʃaɪld]                             | n. 孩子，儿童
+chimney                        | [ˈtʃɪmnɪ]                            | n. 烟囱，烟筒
+China                          | [ˈtʃaɪnə]                            | n. 中国
+Chinese                        | [tʃaɪˈniːz]                          | a. 中国的；中国人的；汉语的 n. 中国人；汉语，
+chocolate                      | [ˈtʃɔklit]                           | n. 巧克力
+choose (chose, chosen)         | [tʃuːz]                              | vt. 选择
+Christmas                      | [ˈkrɪsməs]                           | n. 圣诞节
+church                         | [tʃɜːtʃ]                             | n. 教堂；教会
+cinema                         | [ˈsɪnimə]                            | n. 电影院；电影
+circle                         | [ˈsɜːk(ə)l]                          | n. /vt. 圆,环绕
+city                           | [ˈsɪtɪ]                              | n. 市，城市，都市
+class                          | [klɑːs; (US) klæs]                   | n.（学校的）班；年级；课
+classmate                      | [ˈklɑːsmeɪt]                         | n. 同班同学
+classroom                      | [ˈklɑːsruːm]                         | n. 教室
+clean                          | [kliːn]                              | vt. 弄干净，擦干净 a. 清洁的，干净的
+clear                          | [klɪə(r)]                            | a. 清晰；明亮的；清楚的
+clearly                        | [ˈklɪəlɪ]                            | ad. 清楚地，无疑地
+clever                         | [ˈklevə(r)]                          | a. 聪明的，伶俐的
+climb                          | [klaɪm]                              | v. 爬，攀登
+clock                          | [klɔk]                               | n. 钟
+close                          | [kləʊz]                              | a. 亲密的；近，靠近 ad. 近，靠近 vt. 关，关闭
+cloth                          | [klɔθ; (US) klɔθ]                    | n. 布
+clothes                        | [klɔðz; (US) kləʊz]                  | n. 衣服；各种衣物
+cloud                          | [ˈklaʊd]                             | n. 云；云状物；阴影
+cloudy                         | [ˈklaʊdɪ]                            | a. 多云的，阴天的
+club                           | [klʌb]                               | n. 俱乐部；纸牌中的梅花
+coal                           | [kəʊl]                               | n. 煤；煤块
+coat                           | [kəʊt]                               | n. 外套；涂层；表皮；皮毛
+cock                           | [kɔk]                                | n. 公鸡
+code                           | [kəʊd]                               | n. 密码,符号,准则
+cocoa                          | [ˈkəʊkəʊ]                            | n. 可可粉
+coffee                         | [ˈkɔfɪ; (US) ˈkɔːfɪ]                 | n. 咖啡
+coin                           | [kɔɪn]                               | n. 硬币
+coke                           | [kəʊk]                               | n. 可口可乐
+cold                           | [kəʊld]                              | a. 冷的，寒的 n. 寒冷；感冒，伤风
+collect                        | [kəˈlekt]                            | vt. 收集，搜集
+college                        | [ˈkɔlɪdʒ]                            | n. 学院；专科学校
+colour (美color)               | ['kʌlə]                              | n. 颜色 vt. 给…着色，涂色
+come (came, come)              | [kʌm]                                | vi. 来，来到
+comfort                        | [ˈkʌmfət]                            | n. 安慰；慰问
+comfortable                    | [ˈkʌmfətəb(ə)l; (US) ˈkʌmfərtəbl]    | a. 舒服的；安逸的；舒服自在的
+common                         | [ˈkɔmən]                             | a. 普通，一般；共有的
+company                        | [ˈkʌmpənɪ]                           | n. 公司
+competition                    | [kɔmpəˈtɪʃ(ə)n]                      | n. 比赛，竞赛
+complain                       | [kəmˈplein]                          | v. 抱怨,投诉
+composition                    | [kɔmpəːziʃ(ə)n]                      | n. 作文；作曲
+computer                       | [kəmˈpjuːtə(r)]                      | n. 电子计算机
+computer game                  | [kəmˈpjuːtə(r) ɡeim]                 | 电子游戏
+comrade                        | [ˈkɔmrid; (US) ˈkɑmræd]              | n. 同志
+concert                        | [ˈkɔnsət]                            | n. 音乐会；演奏会
+conductor                      | [kənˈdʌktə(r)]                       | n. 指导者;（车上的）售票员，列车员;乐队指挥
+confident                      | [ˈkɔnfɪdənt]                         | a. 自信的
+congratulate                   | [kənˈɡrætjʊleɪt]                     | vt. 祝贺
+congratulation                 | [kənɡrætjʊˈleɪʃ(ə)n]                 | n. 祝贺，庆贺
+connect                        | [kəˈnekt]                            | v. 连接，把…联系起来
+continue                       | [kənˈtɪnjuː]                         | vi. 继续
+conversation                   | [kɔnvəˈseɪʃ(ə)n]                     | n. 谈话，交谈
+cook                           | [kʊk]                                | n. 炊事员,厨师 v. 烹调,做饭
+cookie                         | [ˈkʊkɪ]                              | n. 小甜饼
+cool                           | [kuːl]                               | a. 凉的，凉爽的；酷
+copy                           | [ˈkɔpɪ]                              | n. 抄本，副本；一本（份，册…） v. 抄写,复印,拷贝
+corn                           | [kɔːn]                               | n. 玉米，谷物
+corner                         | [ˈkɔːnə(r)]                          | n. 角；角落；拐角
+correct                        | [kəˈrekt]                            | v. 改正；纠正 a. 正确的，对的；恰当的
+cost (cost, cost)              | [kɔst; (US) kɔːst]                   | v.值（钱），花费 n. 价格
+cotton                         | [ˈkɔt(ə)n]                           | n. 棉花 a. 棉花的
+cough                          | [kɔf; (US) kɔːf]                     | n.& vi. 咳嗽
+could                          | [kʊdˈ]                               | v.（can的过去式）可以…；（表示许可或请求）可以…，行
+count                          | [kaʊnt]                              | vt. 数，点数
+country                        | [ˈkʌntrɪ]                            | n. 国家；农村，乡下
+countryside                    | [ˈkʌntrɪsaɪd]                        | n. 乡下，农村
+couple                         | [ˈkʌp(ə)l]                           | n. 夫妇，一对
+course                         | [kɔːs]                               | n. 过程；经过；课程
+cousin                         | [ˈkʌz(ə)n]                           | n. 堂（表）兄弟，堂（表）姐妹
+cover                          | [ˈkʌvə(r)]                           | n. 盖子；罩 v. 覆盖，遮盖；掩盖
+cow                            | [kaʊ]                                | n. 母牛，奶牛
+crash                          | [kræʃ]                               | v. / n. 碰撞，撞击
+cream                          | [kriːm]                              | n. 奶油，乳脂
+crop                           | [krɔp]                               | n. 庄稼；收成
+cross                          | [krɔs]                               | a. 脾气不好的，易怒的 n. 十字形的东西 vt. 越过；穿过
+crossing                       | [ˈkrɔsɪŋ]                            | n. 十字路口，人行横道
+crowd                          | [kraʊd]                              | n. 人群 vt. 拥挤，群聚
+cry                            | [kraɪ]                               | n. 叫喊；哭声 v. 喊叫；哭
+culture                        | [ˈkʌltʃə(r)]                         | n. 文化
+cup                            | [kʌp]                                | n. 茶杯
+cupboard                       | [ˈkʌbəd]                             | n. 碗柜；橱柜
+curtain                        | [ˈkɜːt(ə)n]                          | n. 窗帘
+cushion                        | [ˈkʊʃ(ə)n]                           | n. 垫子
+customer                       | [ˈkʌstəmə(r)]                        | n.（商店）顾客，主顾
+cut (cut, cut)                 | [kʌt]                                | v. 切，剪，削，割
+cute                           | [kju:t]                              | adj.可爱的
+dad = daddy                    | [dæd]                                | n.（口）爸爸，爹爹
+daily                          | [ˈdeɪlɪ]                             | a. 每日的；日常的 ad. 每天 n. 日报
+dance                          | [dɑːns; (US) dæns]                   | n.& vi. 跳舞
+dangerous                      | [ˈdeɪndʒərəs]                        | a. 危险的
+dare                           | [deə(r)]                             | v.& aux. 敢，敢于
+dark                           | [dɑːk]                               | n. 黑暗；暗处；日暮 a. 黑暗的；暗淡的；深色的
+date                           | [deɪt]                               | n. 日期；约会 n.枣
+daughter                       | [ˈdɔːtə(r)]                          | n. 女儿
+day                            | [deɪ]                                | n.（一）天，（一）日；白天
+daytime                        | [ˈdeɪtaɪm]                           | n. 白天，白昼
+dead                           | [ded]                                | a. 死的；无生命的
+deaf                           | [def]                                | a. 聋的
+deal                           | [diːl]                               | n. 量，数额；交易
+dear                           | [dɪə(r)]                             | int.（表示惊愕）哎呀！唷！a. 亲爱的；贵的
+death                          | [deθ]                                | n. 死
+December                       | [dɪˈsembə(r)]                        | n. 12月
+decide                         | [dɪˈsaɪd]                            | v. 决定；下决心
+decision                       | [dɪˈsɪʒ(ə)n]                         | n. 决定；决心
+decorate                       | [ˈdekəreɪt]                          | vt. 装饰，修饰
+deep                           | [diːp]                               | a. 深 ad. 深；深厚
+deeply                         | [ˈdiːplɪ]                            | ad. 深深地
+deer                           | [dɪə(r)]                             | n. 鹿
+delicious                      | [dɪˈlɪʃəs]                           | a. 美味的，可口的
+delight                        | [dɪˈlaɪt]                            | n. 快乐；乐事
+demand                         | [dɪˈmɑːnd; (US) dɪˈmænd]             | vt. 要求
+depend                         | [dɪˈpend]                            | vi. 依靠，依赖，指望；取决于
+describe                       | [dɪˈskraɪb]                          | vt. 描写，叙述
+description                    | [dɪˈskrɪpʃ(ə)n]                      | n. 描述，描写
+desert                         | [dɪˈzɜːt]                            | n. 沙漠 vt. 舍弃；遗弃
+deserve                        | [dɪˈzɜːv]                            | v.（不用于进行时态）应得，应受
+desk                           | [desk]                               | n. 书桌，写字台
+destroy                        | [dɪˈstrɔɪ]                           | vt. 破坏，毁坏
+detective                      | [dɪˈtektɪv]                          | n. 侦探
+develop                        | [dɪˈveləp]                           | v.（使）发展；开发 vt. 冲洗（照片）
+diagram                        | [ˈdaɪəɡræm]                          | n. 图表，图样
+dial                           | [ˈdaɪ(ə)l]                           | vt. 拨（电话号码）
+dialogue                       | [ˈdaɪəlɔɡ; (US) ˈdaɪəlɔːɡ]           | n. 对话
+diary                          | [ˈdaɪərɪ]                            | n. 日记；日记簿
+dictation                      | [dɪkˈteɪʃ(ə)n]                       | n. 听写
+dictionary                     | [ˈdɪkʃənərɪ; (US) ˈdɪkʃənerɪ]        | n. 词典，字典
+die                            | [daɪ]                                | v. 死
+difference                     | [ˈdɪfərəns]                          | n. 不同
+different                      | [ˈdɪfərənt]                          | a. 不同的，有差异的
+difficult                      | [ˈdɪfɪkəlt]                          | a. 难；艰难；不易相处的
+difficulty                     | [ˈdɪfɪkəltɪ]                         | n. 困难，费力
+dig (dug, dug)                 | [dɪɡ]                                | v. 挖（洞沟）,掘
+digital                        | [ˈdɪdʒɪt(ə)l]                        | a. .数字的，数码的
+dim                            | [dɪm]                                | a. 昏暗的,暗淡的
+dining-room                    | ['dainiŋ-rʊm]                        | 食堂，饭厅
+dinner                         | [ˈdɪnə(r)]                           | n. 正餐，宴会
+dip                            | [dɪp]                                | vt. 浸，蘸；把…放入又取出
+direct                         | [dɪˈrekt, daɪˈrekt]                  | a. 直接的；直截了当的 vt. 指挥；指导；导演（电影）
+direction                      | [dɪˈrekʃ(ə)n, daɪˈrekʃ(ə)n]          | n. 方向；方位
+director                       | [dɪˈrektə(r)]                        | n. 所长，处长，主任；董事；导演
+directory                      | [dɪˈrektərɪ]                         | n. 姓名地址录
+dirt                           | [dɜːt]                               | n. 污物；脏物
+dirty                          | [ˈdɜːtɪ]                             | a. 脏的
+disappear                      | [dɪsəˈpɪə(r)]                        | vi. 消失
+discover                       | [dɪˈskʌvə(r)]                        | vt. 发现
+discovery                      | [dɪˈskʌvərɪ]                         | n. 发现
+discuss                        | [dɪsˈkʌs]                            | vt. 讨论，议论
+discussion                     | [dɪsˈkʌʃ(ə)n]                        | n. 讨论，辩论
+disease                        | [dɪˈziːz]                            | n. 病，疾病
+dish                           | [dɪʃ]                                | n. 盘，碟；盘装菜；盘形物
+display                        | [dɪsˈplei]                           | vt. 陈列,展览;显露,表现n. 陈列,展览;展览品,展览品
+disturb                        | [dɪˈstɜːb]                           | vt. 扰乱；打扰
+dive                           | [daɪv]                               | vi. 跳水
+divide                         | [dɪˈvaɪd]                            | vt. 分，划分
+do (did, done)                 | [dʊ, duː]                            | v. & aux. 做，干
+doctor                         | [ˈdɔktə(r)]                          | n. 医生，大夫；博士
+dog                            | [dɔɡ; (US) dɔːɡ]                     | n. 狗
+doll                           | [dɔl; (US) dɔːl]                     | n. 玩偶，玩具娃娃
+dollar                         | [dɔlə]                               | n. 元（美国、加拿大、澳大利亚等国货币单位）
+door                           | [dɔː(r)]                             | n. 门
+double                         | [ˈdʌb(ə)l]                           | a. 两倍.双的 n. 两个.双
+down                           | [daʊn]                               | prep. 沿着，沿…而下 ad. 向下
+download                       | ['daunləud]                          | n.& v. 下载
+downstairs                     | [ˈdaʊnsteəz]                         | ad. 在楼下；到楼下
+downtown                       | [ˈdaʊntaʊn]                          | n. 城市的商业区，中心区，闹市区 a. 商业区的,闹市区的
+dozen                          | [ˈdʌzn]                              | n. 十二个；几十，许多
+drag                           | [dræɡ]                               | v. 拖；拽
+dragon                         | [ˈdræɡən]                            | n.龙
+draw (drew, drawn)             | [drɔː]                               | v. 绘画；绘制；拉，拖；提取（金钱）
+drawer                         | [drɔ:ə]                              | n. 抽屉
+drawing                        | [ˈdrɔːɪŋ]                            | n. 图画，素描,绘画
+dream (dreamt, dreamt 或-ed, -ed) | [driːm]                              | n.& vt. 梦，梦想
+dress                          | [dres]                               | n. 女服，连衣裙；(统指)服装；童装 v. 穿衣
+drink                          | [drɪŋk]                              | n. 饮料；喝酒 
+drop                           | [drɔp]                               | n.滴 v.掉下,落下,投递,放弃
+drought                        | [draut]                              | n. 干旱
+drunk                          | [drʌŋk]                              | a. 醉的
+dry                            | [draɪ]                               | v. 使…干；弄干；擦干 a. 干的；干燥的
+duck                           | [dʌk]                                | n. 鸭子
+dumpling                       | [ˈdʌmplɪŋ]                           | n. 饺子
+during                         | [ˈdjuərɪŋ; (US) ˈdɪərɪŋ]             | prep. 在…期间；在…过程中
+dusk                           | [dʌsk]                               | n. 黄昏
+dust                           | [dʌst]                               | n. 灰尘，尘土
+dustbin                        | [ˈdʌstbɪn]                           | n. 垃圾箱
+duty                           | [ˈdjuːtɪ]                            | n. 责任，义务
+dynasty                        | [daineist]                           | n.王朝，朝代
+each                           | [iːtʃ]                               | a.& pron. 每人,每个,每件
+ear                            | [ɪə(r)]                              | n.耳朵.耳状物；听力，听觉
+early                          | [ɜːlɪ]                               | a. 早的 ad. 早地
+earth                          | [ɜːθ]                                | n. 地球；土，泥；大地
+earthquake                     | [ˈɜːθkweɪk]                          | n. 地震
+east                           | [iːst]                               | a. 东方；东部的；ad. 在东方；向东方； n. 东，东方；
+easy                           | [ˈiːzɪ]                              | a. 容易的，不费力的
+eat (ate, eaten)               | [iːt]                                | v. 吃
+edge                           | [edʒ]                                | n. 边缘
+education                      | [edjʊːkeɪʃ (ə)n]                     | n. 教育，培养
+egg                            | [eɡ]                                 | n. 蛋；卵
+Egypt                          | [ˈiːdʒɪpt]                           | n. 埃及
+Egyptian                       | [ɪˈdʒɪpʃ(ə)n]                        | a. 埃及的；埃及人的；埃及语的 n. 埃及人
+eight                          | [eɪt]                                | num. 八
+eighteen                       | [ˈeɪˈtiːn]                           | num. 十八
+eighth                         | [eɪθ]                                | num. 第八
+eighty                         | [ˈeɪtɪ]                              | num. 八十
+either                         | [ˈaɪðə(r)]                           | a. 两方任一方的；二者之一 conj. 二者之一；要么 ad. 也
+elder                          | [ˈeldə(r)]                           | n. 长者；前辈
+electricity                    | [ɪlekˈtrɪsɪtɪ]                       | n. 电；电流
+elephant                       | [ˈelɪfənt]                           | n. 象
+elevator                       | [ˈelɪveitə]                          | n. 电梯,升降梯
+eleven                         | [ɪˈlev(ə)n]                          | num. 十一
+else                           | [els]                                | ad. 别的，其他的
+e-mail                         | [iː-meɪl]                            | n. 电子邮件
+empty                          | [ˈemptɪ]                             | a. 空的
+encourage                      | [ɪnˈkʌrɪdʒ]                          | vt. 鼓励
+end                            | [end]                                | n. 末尾；终点；结束 v. 结束，终止
+enemy                          | [ˈenɪmɪ]                             | n. 敌人；敌军
+engineer                       | [endʒɪˈnɪə(r)]                       | n. 工程师；技师
+England                        | [ˈɪŋɡlənd]                           | n. 英格兰
+English                        | [ˈɪŋɡlɪʃ]                            | a. 英国的，英国人的，英语的 n. 英语
+English-speaking               | [ˈɪŋɡlɪʃ-spiːkɪŋ]                    | a.说英语的
+enjoy                          | [ɪnˈdʒɔɪ]                            | vt. 欣赏；享受乐趣；喜欢
+enjoyable                      | [ɪnˈdʒɔɪəb(ə)l]                      | a. 愉快的；有趣的
+enough                         | [ɪˈnʌf]                              | n. 足够；充足 a. 足够；充分的 ad. 足够地；充分地
+enter                          | [ˈentə(r)]                           | vt. 进入
+entrance                       | [ˈentrəns]                           | n. 入口;入场;进入的权利;入学许可
+entry                          | [ˈentrɪ]                             | n. 进入
+envelope                       | [ˈenvələʊp]                          | n. 信封
+environment                    | [ɪnˈvaɪərənmənt]                     | n.环境
+envy                           | [ˈenvɪ]                              | vt.& n. 忌妒； 羡慕
+equal                          | [ˈiːkw(ə)l]                          | a. 平等的 vt. 等于，使等于
+equality                       | [iːˈkwɔlətɪ]                         | n. 平等
+equip                          | [ɪˈkwɪp]                             | vt. 提供设备；装备；配备
+equipment                      | [ɪˈkwɪpmənt]                         | n. 装备，设备
+eraser                         | [ɪˈreɪzə(r)]                         | n. 橡皮擦；黑板擦
+error                          | [ˈerə(r)]                            | n. 错误；差错
+escape                         | [ɪˈskeɪp]                            | n.& vi. 逃跑；逃脱
+especially                     | [ɪˈspeʃəlɪ]                          | ad. 特别，尤其
+essay                          | [ˈeseɪ]                              | n. 散文；文章；随笔
+Europe                         | [ˈjʊərəp]                            | n. 欧洲
+European                       | [jʊərəˈpiːən]                        | a. 欧洲的，欧洲人的 n. 欧洲人
+Eve                            | [i:v]                                | n.前夕
+even                           | [ˈiːv(ə)n]                           | ad. 甚至，连（…都）；更
+evening                        | [ˈiːvnɪŋ]                            | n. 傍晚，晚上
+event                          | [ɪ'vent]                             | n. 事件，大事
+ever                           | [ˈevə(r)]                            | ad. 曾经；无论何时
+every                          | [ˈevrɪ]                              | a. 每一，每个的
+everybody                      | [ˈevrɪbɔdɪ]                          | pron. 每人，人人
+everyday                       | [ˈevrɪdeɪ]                           | a. 每日的；日常的
+everyone                       | [ˈevrɪwʌn]                           | pron. 每人，人人
+everything                     | [ˈevrɪθɪŋ]                           | pron. 每件事，事事
+everywhere                     | [ˈevrɪweə(r)]                        | ad. 到处
+exact                          | [ɪɡˈzækt]                            | a. 精确的；确切的
+exactly                        | [ɪɡˈzæktlɪ]                          | ad. 精确地；确切地
+exam = examination             | [ɪɡzæmɪˈneɪʃ(ə)n]                    | n. 考试，测试；检查；审查
+examine                        | [ɪɡˈzæmɪn]                           | vt. 检查；诊察
+example                        | [ɪɡˈzɑːmp(ə)l; (US) ɪɡˈzæmpl]        | n. 例子；榜样
+excellent                      | [ˈeksələnt]                          | a. 极好的，优秀的
+except                         | [ɪkˈsept]                            | prep. 除…之外
+excite                         | [ɪkˈsaɪt]                            | vt. 使兴奋，使激动
+excuse                         | [ɪkˈskjuːz]                          | n. 借口,辩解 vt. 原谅,宽恕
+exercise                       | [ˈeksəsaɪz]                          | n. 锻炼，做操；练习，习题 vi. 锻炼
+exhibition                     | [eksɪˈbɪʃ(ə)n]                       | n. 展览；展览会
+exist                          | [ɪg'zɪst]                            | vi. 存在
+expect                         | [ɪkˈspekt]                           | vt. 预料；盼望；认为
+expensive                      | [ɪkˈspensɪv]                         | a. 昂贵的
+experience                     | [ɪkˈspɪərɪəns]                       | n. 经验；经历
+experiment                     | [ɪkˈsperɪmənt]                       | n. 实验
+expert                         | [ˈekspɜːt]                           | n. 专家，能手
+explain                        | [ɪksˈpleɪn]                          | vt. 解释，说明
+express                        | [ɪkˈspres]                           | vt. 表达；表示；表情 n. 快车，特快专递
+eye                            | [aɪ]                                 | n. 眼睛
+face                           | [feɪs]                               | n. 脸 vt. 面向；面对
+fact                           | [fækt]                               | n. 事实，现实
+factory                        | [ˈfæktəri]                           | n. 工厂
+fail                           | [feɪl]                               | v. 失败；不及格；衰退
+fame                           | [feɪm]                               | n. 名声,名望,名誉
+family                         | [ˈfæmɪlɪ]                            | n. 家庭；家族；子女
+famous                         | [ˈfeɪməs]                            | a. 著名的
+fan                            | [fæn]                                | n.（电影、运动等的）迷；热心的爱好者（支持者） n. 风扇
+far                            | [fɑː(r)]                             | (farther, farthest 或further , furthest) a.& ad. 远的；远地
+farm                           | [fɑːm]                               | n. 农场；农庄
+farmer                         | [ˈfɑːmə(r)]                          | n. 农民
+farming                        | [ˈfɑːmiŋ]                            | n. 农业,务农
+farmland                       | [fɑːmlænd]                           | n. 农田
+farther                        | [ˈfɑːðə]                             | a./ad. (far的比较级形式之一)较远,更远
+farthest                       | [ˈfɑːðist]                           | a./ad. (far的最高级形式之一)最远
+fast                           | [ˈfɑːst]                             | a. 快的，迅速的；紧密的 ad. 快地，迅速地；紧密地
+fasten                         | [ˈfɑːs(ə)n; (US) fæsn]               | vt. 扎牢；扣住
+fat                            | [fæt]                                | n. 脂肪 a. 胖的；肥的
+father                         | [ˈfɑːðə(r)]                          | n. 父亲
+favour                         | ['feivə]                             | (美favor) n. 恩惠；好意；帮助
+favourite                      | ['feivərit]                          | (美 favorite) a. 喜爱的 n. 特别喜爱的人（或物）
+fax                            | [fæks]                               | n. 传真
+fear                           | [fiə(r)]                             | n. 害怕；恐惧； 担忧
+feather                        | ['feðə(r)]                           | n. 羽毛
+February                       | ['februəri]                          | n. 2月
+federal                        | ['fedər(ə)l]                         | a. 中央的,（政府）联邦的
+fee                            | [fiː]                                | n. 费，费用
+feed (fed, fed)                | [fiːd]                               | vt. 喂（养）；饲（养）
+feel (felt, felt)              | [fiːl]                               | v.& link 感觉，觉得；摸，触
+feeling                        | [ˈfiːlɪŋ]                            | n. 感情；感觉
+fence                          | [fens]                               | n. 栅栏；围栏；篱笆
+festival                       | [ˈfestɪvəl]                          | n. 节日
+fetch                          | [fetʃ]                               | vt.（去）取（物）来，（去）带（人）来
+fever                          | [ˈfiːvə(r)]                          | n. 发烧；发热
+few                            | [fjuː]                               | pron. 不多;少数;不多的;少数的
+field                          | [fiːld]                              | n. 田地;牧场;场地
+fifteen                        | [fɪfˈtiːn]                           | num. 十五
+fifth                          | [fɪfθ]                               | num. 第五
+fifty                          | [ˈfɪftɪ]                             | num. 五十
+fight                          | [faɪt]                               | n. 打仗（架），争论
+fight                          | [faɪt]                               | (fought, fought) n./v. 打仗（架），与…打仗（架）
+fill                           | [fɪl]                                | vt. 填空，装满
+film                           | [fɪlm]                               | n. 电影；影片；胶卷
+final                          | [ˈfaɪn(ə)l]                          | a. 最后的；终极的
+find                           | [faɪnd]                              | (found, found) vt. 找到，发现，感到
+fine                           | [faɪn]                               | a. 晴朗的；美好的；（身体）健康的
+finger                         | [ˈfɪŋɡə(r)]                          | n. 手指
+finish                         | [ˈfɪnɪʃ]                             | v. 结束；做完
+fire                           | [ˈfaɪə(r)]                           | n. 火；火炉；火灾 vi. 开火,射击,解雇
+fireplace                      | [ˈfaɪəpleɪs]                         | n. 壁炉
+first                          | [fɜːst]                              | num. 第一 a.& ad. 第一；首次；最初 n. 开始；开端
+fish                           | [fɪʃ]                                | n. 鱼；鱼肉 vi. 钓鱼；捕鱼
+fisherman                      | [ˈfɪʃəmən]                           | n. 渔民；钓鱼健身者
+fit                            | [fɪt]                                | a. 健康的,适合的 v.（使）适合,安装
+five                           | [faɪv]                               | num. 五
+fix                            | [fɪks]                               | vt. 修理；安装；确定，决定
+flag                           | [flæɡ]                               | n. 旗；标志；旗舰
+flight                         | [flait]                              | n. 航班,飞行
+flood                          | [flʌd]                               | n. 洪水 vt. 淹没，使泛滥
+floor                          | [flɔː(r)]                            | n. 地面，地板.（楼房的）层
+flower                         | [ˈflaʊə(r)]                          | n. 花
+fly (flew, flown)              | [flaɪ]                               | vi. 飞；飞行；飘动 vt. 放（风筝、飞机模型等）n. 苍蝇
+focus                          | [ˈfəʊkəs]                            | v. / n. 集中（注意力，精力）于，焦点，中心点
+fog                            | [fɔɡ]                                | n. 雾
+foggy                          | [ˈfɔɡɪ]                              | a. 多雾的
+follow                         | [ˈfɔləʊ]                             | vt. 跟随；仿效；跟得上
+following                      | [ˈfɔləʊɪŋ]                           | a. 接着的；以下的
+fond                           | [fɔnd]                               | a. 喜爱的，爱好的
+food                           | [fuːd]                               | n. 食物，食品
+fool                           | [fuːl]                               | n. 傻子，蠢人
+foolish                        | [ˈfuːlɪʃ]                            | a. 愚蠢的，傻的
+foot (复feet)                  | [fʊt]                                | n. 足，脚；英尺
+football                       | [ˈfutbɔːl]                           | n.（英式）足球；（美式）橄榄球
+for                            | [fə(r), f ɔː (r)]                    | prep. 为了…；因为…；对于…；对…来说 conj. 因为，由于
+foreign                        | [ˈfɔrən; (US) ˈfɔrɪn]                | a. 外国的
+foreigner                      | [ˈfɔrənə(r)]                         | n. 外国人
+forest                         | [ˈfɔrɪst]                            | n. 森林
+forever                        | [fəˈrevə(r)]                         | ad. 永远；永恒的
+forget (forgot, forgotten)     | [fəˈɡet]                             | v. 忘记；忘掉
+forgetful                      | [fəˈɡetfʊl]                          | a. 健忘的，不留心的
+fork                           | [fɔːk]                               | n. 叉，餐叉
+form                           | [fɔːm]                               | n. 表格；形式；结构
+forth                          | [fɔːθ]                               | n. 向前,往外
+forty                          | [ˈfɔːtɪ]                             | num. 四十
+found                          | [faʊnd]                              | vt. 成立，建立
+foundation                     | [faʊnˈdeiʃən]                        | n. 基础;基本原理,根据,基金会;建立,创办
+fountain                       | [ˈfaʊntɪn; (US) ˈfaʊntn]             | n. 喷泉
+four                           | [fɔː(r)]                             | num. 四
+fourteen                       | [ˈfɔːˈtiːn]                          | num. 十四
+fourth                         | [ˈfɔːθ]                              | num. 第四
+fox                            | [fɔks]                               | n. 狐狸
+France                         | [fræns]                              | n. 法国
+free                           | [friː]                               | a. 自由，空闲的；免费的
+freeze                         | [friːz]                              | (froze, frozen) vi. 结冰
+French                         | [frentʃ]                             | n. 法语 a. 法国的；法国人的；法语的
+Frenchman                      | [ˈfrentʃmən]                         | (复 Frenchmen) n. 法国人（男）
+fresh                          | [freʃ]                               | a. 新鲜的
+Friday                         | [ˈfraɪdɪ]                            | n. 星期五
+fridge =refrigerator           | [rɪˈfrɪdʒəreɪtə(r)]                  | n. 冰箱
+friend                         | [frend]                              | n. 朋友
+friendly                       | [ˈfrendlɪ]                           | a. 友好的
+friendship                     | [ˈfrendʃɪp]                          | n. 友谊，友情
+frighten                       | [ˈfraɪt(ə)n]                         | vt. 使惊恐，吓唬
+from                           | [frəm, frɔm]                         | prep. 从,从…起,来自
+front                          | [frʌnt]                              | a. 前面的；前部的 n. 前面；前部；前线
+fruit                          | [fruːt]                              | n. 水果；果实
+fruit juice                    | [fruːt dʒuːs]                        | n. 果汁
+fry                            | [fraɪ]                               | vt. 用油煎；用油炸
+full                           | [fʊl]                                | a. 满的，充满的；完全的
+fun                            | [fʌn]                                | n. 有趣的事，娱乐，玩笑
+funny                          | [ˈfʌnɪ]                              | a. 有趣的，滑稽可笑的
+fur                            | [fɜː(r)]                             | n. 毛皮；皮子
+further                        | [ˈfəðə]                              | a./ad. (far的比较级形式之一)较远,更远
+future                         | [ˈfjuːtʃə(r)]                        | n. 将来、未来
+game                           | [ɡeɪm]                               | n. 游戏；运动；比赛
+garden                         | [ˈɡɑːd(ə)n]                          | n. 花园，果园，菜园
+gate                           | [ɡeɪt]                               | n. 大门
+general                        | [ˈdʒenər(ə)l]                        | a. 大体，笼统的，总的
+generation                     | [dʒenəˈreɪʃ(ə)n]                     | n. 代，一代
+generous                       | [ˈdʒenərəs]                          | a. 慷慨大方的
+geography                      | [dʒɪˈɔɡrəfɪ]                         | n. 地理学
+geometry                       | [dʒɪ'ɑmɪtrɪ]                         | n. 几何学
+German                         | [ˈdʒɜːmən]                           | a. 德国的，德国人的，德语的 n. 德国人，德语
+Germany                        | [ˈdʒɜːmənɪ]                          | n. 德国
+get (got , got)                | [ɡet]                                | vt. 成为；得到；具有；到达
+gift                           | [ɡɪft]                               | n. 赠品；礼物
+girl                           | [ɡɜːl]                               | n. 女孩
+give (gave, given)             | [ɡɪv]                                | vt. 给,递给,付出,给予
+glad                           | [ɡlæd]                               | a. 高兴的；乐意的
+glass                          | [ɡlɑːs; (US) ɡlæs]                   | n. 玻璃杯,玻璃；(复)眼镜
+glove                          | [ɡlʌv]                               | n. 手套
+go (went, gone)                | [ɡəʊ]                                | vi. 去；走；驶；通到；到达 n. 尝试（做某事）
+goal                           | [ɡəʊl]                               | n.（足球）球门，目标
+goat                           | [ɡəʊt]                               | n. 山羊
+gold                           | [ɡəʊld]                              | n. 黄金 a 金的，黄金的
+golf                           | [ɡɔlf]                               | n. 高尔夫球
+good (better,best)             | [ɡʊd]                                | a. 好；良好
+good-bye                       | [ɡʊd-baɪ]                            | int. 再见；再会
+goodness                       | [ˈɡʊdnɪs]                            | n. 善良，美德
+goose (复 geese)               | [ɡuːs]                               | n. 鹅
+government                     | [ˈɡʌvənmənt]                         | n. 政府
+grade                          | [ɡreɪd]                              | n. 等级（中小学的）；学年；成绩，分数
+gradually                      | [ˈɡrædjʊəlɪ]                         | ad. 逐渐地
+graduate                       | [ˈɡrædjʊeit ˈɡrædʒueit ]             | v. 毕业
+grammar                        | [ˈɡræmə(r)]                          | n. 语法
+grand                          | [ɡrænd]                              | a. 宏伟的
+grandchild                     | ['græntʃaɪld]                        | n. (外)孙或孙女,孙辈
+granddaughter                  | [ˈɡrændɔːtə(r)]                      | n.（外）孙女
+grandma = grandmother          | [ˈɡrænmɑː, ˈɡrændmʌðə(r)]            | n. 奶奶；外婆
+grandpa = grandfather          | [ˈɡrænpɑː, ˈɡrændfɑːðə(r)]           | n. 爷爷,外公
+grandparents                   | [ˈɡrændpeərənts]                     | n. 祖父母,外祖父母
+grandson                       | [ˈɡrændsʌn]                          | n.（外）孙子
+granny                         | [ˈɡrænɪ]                             | n. 老奶奶；祖母；外婆
+grape                          | [ɡreɪp]                              | n. 葡萄
+grass                          | [ɡrɑːs; (US) ɡræs]                   | n. 草；草场；牧草
+grateful                       | [ˈɡreɪtfʊl]                          | a. 感激的，感谢的
+great                          | [ɡreɪt]                              | a. 伟大的,重要的,好极了 ad.（口语）好极了，很好
+Greece                         | [ɡriːs]                              | n. 希腊
+green                          | [ɡriːn]                              | a. 绿色的；青的 n. 绿色
+greet                          | [ɡriːt]                              | vt. 问候；向…致敬
+grey / gray                    | [ɡreɪ]                               | a. 灰色的；灰白的
+group                          | [ɡruːp]                              | n. 组，群
+grow (grew, grown)             | [ɡrəʊ]                               | v. 生长；发育；种植；变成
+growth                         | [ɡrəʊθ]                              | n. 生长，增长
+guess                          | [ɡes]                                | vi. 猜
+guest                          | [ɡest]                               | n. 客人，宾客
+guide                          | [ɡaɪd]                               | n. 向导，导游者
+guitar                         | [ɡɪˈtɑː(r)]                          | n. 吉他，六弦琴
+gun                            | [gʌn]                                | n.炮，枪
+gym                            | [dʒɪm]                               | n.体育馆，健身房
+habit                          | [ˈhæbɪt]                             | n. 习惯，习性
+hair                           | [heə(r)]                             | n. 头发
+haircut                        | [ˈheəkʌt]                            | n.（男子）理发
+half                           | [hɑːf; (US) hæf]                     | a.& n. 半，一半，半个
+hall                           | [hɔːl]                               | n. 大厅,会堂,礼堂;过道
+ham                            | [hæm]                                | n. 火腿
+hamburger                      | [ˈhæmbɜːɡə(r)]                       | n. 汉堡包
+hand                           | [hænd]                               | n. 手；指针 v. 递;给;交付;交上
+handbag                        | [ˈhændbæɡ]                           | n. 女用皮包，手提包
+handwriting                    | [ˈhændraɪtɪŋ]                        | n. 书法
+hang (hung, hung)              | [hæŋ]                                | v. 悬挂，吊着；把…吊起hang (hung, hung) 绞死
+happen                         | [ˈhæpən]                             | vi.（偶然）发生,碰巧
+happily                        | ['hæpɪlɪ]                            | ad. 幸福地，快乐地
+happy                          | [ˈhæpɪ]                              | a. 幸福；快乐的，高兴的
+hard                           | [hɑːd]                               | ad. 努力地；猛烈地 a. 硬的；困难的；艰难的
+hardly                         | [ˈhɑːdlɪ]                            | ad. 几乎不
+hardworking                    | ['ha:d'wə:kiŋ]                       | a. 努力工作的
+harm                           | [hɑːm]                               | n.&v. 伤害；损伤
+harvest                        | [ˈhɑːvɪst]                           | n.& vt. 收割，收获（物）
+hat                            | [hæt]                                | n. 帽子(一般指有边的)；礼帽
+hate                           | [heɪt]                               | vt.& n. 恨，讨厌
+have (has, had, had)           | [hæv]                                | vt. 有；吃；喝；进行；经受
+he                             | [heɪ]                                | pron. 他
+head                           | [hed]                                | n. 头；头脑；首脑；标题 a. 头部的；主要的 v. 率领；驶向
+headache                       | [ˈhedeɪk]                            | n. 头疼
+headmaster                     | [hedˈmɑːstə(r)]                      | n.（英）中小学校长
+headmistress                   | ['hed'mistrɪs]                       | n. 女校长
+headteacher                    | ['hed'tiːtʃə(r)]                     | n. 中小学班主任
+health                         | [helθ]                               | n. 健康，卫生
+healthy                        | [ˈhelθɪ]                             | a. 健康的，健壮的
+hear (heard, heard)            | [hɪə(r)]                             | v. 听见；听说
+hearing                        | [ˈhɪərɪŋ]                            | n. 听力
+heart                          | [hɑːt]                               | n. 心,心脏,纸牌中的红桃
+heat                           | [hiːt]                               | n. 热 vt. 把…加热
+heaven                         | [ˈhev(ə)n]                           | n. 天，天空
+heavy                          | [ˈhevɪ]                              | a. 重的
+heavily                        | [ˈhevɪlɪ]                            | ad. 重地，大量地
+hello                          | [həˈləʊ]                             | int. 喂；你好（表示打招呼，问候或唤起注意）
+help                           | [help]                               | n. & vt. 帮助，帮忙
+helpful                        | [ˈhelpfʊl]                           | a. 有帮助的，有益的
+hen                            | [hen]                                | n. 母鸡
+her                            | [hɜː(r)]                             | pron. 她(宾格),她的
+here                           | [hɪə(r)]                             | ad. 这里，在这里；向这里
+hero                           | [ˈhɪərəʊ]                            | n. 英雄，勇士，男主角
+hers                           | [hɜːz]                               | pron. 她的
+herself                        | [hɜːˈself]                           | pron. 她自己
+hey                            | [heɪ]                                | int. 嘿！
+hi                             | [haɪ]                                | int. 你好（表示打招呼、问候或唤起注意）
+hide (hid, hidden)             | [haɪd]                               | v. 把…藏起来，隐藏
+high                           | [haɪ]                                | a. 高的;高度的 ad. 高地
+highway                        | [ˈhaɪweɪ]                            | n. 公路,主要交通道路
+hill                           | [hɪl]                                | n. 小山;丘陵;土堆;斜坡
+him                            | [hɪm]                                | pron. 他（宾格）
+himself                        | [hɪmˈself]                           | pron. 他自己
+his                            | [hɪz]                                | pron. 他的
+history                        | [ˈhɪstərɪ]                           | n. 历史，历史学
+hit (hit, hit)                 | [hɪt]                                | n.& vt. 打,撞,击中
+hobby                          | [ˈhɔbi]                              | n. 业余爱好，嗜好
+hold (held, held)              | [həʊld]                              | vt. 拿；抱；握住；举行；进行
+hole                           | [həʊl]                               | n. 洞，坑
+holiday                        | [ˈhɔlədi]                            | n. 假日；假期
+home                           | [həʊm]                               | n. 家 ad. 到家；回家
+homeland                       | [ˈhəʊmlænd]                          | n. 祖国
+hometown                       | [ˈhəʊmtaʊn]                          | n. 故乡
+homework                       | [ˈhəʊmwɜːk]                          | n. 家庭作业
+honest                         | [ˈɔnɪst]                             | a. 诚实的，正直的
+hope                           | [həʊp]                               | n.& v. 希望
+hopeful                        | [ˈhəʊpfʊl]                           | a. 有希望的；有前途的
+hopeless                       | [ˈhəʊplis]                           | a. 没有希望的
+horrible                       | [ˈhɔrɪb(ə)l]                         | a. 令人恐惧；恐怖的
+horse                          | [hɔːs]                               | n. 马
+hospital                       | [ˈhɔspɪt(ə)l]                        | n. 医院
+hot                            | [hɔt,hʌt]                            | a. 热的
+hotel                          | [həʊˈtel]                            | n. 旅馆，饭店，宾馆
+hour                           | [ˈaʊə(r)]                            | n. 小时
+house                          | [haʊs]                               | n. 房子；住宅
+housewife                      | [ˈhaʊswaɪf]                          | n. 家庭主妇
+housework                      | [ˈhaʊswɜːk]                          | n. 家务劳动
+how                            | [haʊ]                                | ad. 怎样,如何；多么
+however                        | [haʊˈevə(r)]                         | ad. 可是 conj. 然而，可是，尽管如此
+hug                            | [hʌɡ]                                | v. 拥抱
+huge                           | [hjuːdʒ]                             | a. 巨大的，庞大的
+human                          | [ˈhjuːmən]                           | a. 人的，人类的
+hundred                        | [ˈhʌndrəd]                           | num. 百
+hunger                         | [ˈhʌŋɡə(r)]                          | n. 饥饿
+hungry                         | [ˈhʌŋɡrɪ]                            | a.（饥）饿的
+hurry                          | [ˈhʌrɪ]                              | vi. 赶快；急忙
+hurt (hurt, hurt)              | [hɜːt]                               | vt. 伤害，受伤；伤人感情
+husband                        | [ˈhʌzbənd]                           | n. 丈夫
+I                              | [aɪ]                                 | pron. 我
+ice                            | [aɪs]                                | n. 冰
+ice-cream                      | [aɪs-kriːm]                          | n. 冰淇淋
+idea                           | [aɪˈdɪə]                             | n. 主意,意见,打算,想法
+idiom                          | [ˈɪdɪəm]                             | n. 习语，成语
+if                             | [ɪf]                                 | conj. 如果,假使,是否,是不是
+ill                            | [ɪl]                                 | a. 有病的；不健康的
+illness                        | [ˈɪlnɪs]                             | n. 疾病
+imagine                        | [ɪˈmædʒɪn]                           | vt. 想像，设想
+immediately                    | [ɪˈmiːdɪətlɪ]                        | ad. 立即
+important                      | [ɪmˈpɔːtənt]                         | a. 重要的
+impossible                     | [ɪmˈpɔsɪb(ə)l]                       | a. 不可能的
+improve                        | [ɪmˈpruːv]                           | vt. 改进，更新
+in                             | [ɪn]                                 | prep. 在…里(内)；在 ad. 在家，在内，向内
+inch                           | [ɪntʃ]                               | n. 英寸
+include                        | [ɪnˈkluːd]                           | vt. 包含，包括
+increase                       | [ɪnˈkriːs]                           | v. & n. 增加，繁殖
+indeed                         | [ɪnˈdiːd]                            | a. 确实；实在
+India                          | [ˈɪndɪə]                             | n. 印度
+Indian                         | [ˈɪndɪən]                            | a.（美洲）印地安人的； 印度人的 n. 印地安人；印度人
+information                    | [ɪnfəˈmeɪʃ(ə)n]                      | n. 信息
+ink                            | [ɪŋk]                                | n. 墨水，油墨
+insect                         | [ˈɪnsekt]                            | n. 昆虫
+inside                         | [ɪnˈsaɪd]                            | prep. 在…里面 ad. 在里面
+insist                         | [ɪnˈsɪst]                            | vi. 坚持；坚决认为
+inspect                        | [ɪnˈspekt]                           | vt. 检查；检验；审视
+instruct                       | [ɪnˈstrʌkt]                          | vt. 通知；指示；教
+instruction                    | [ɪnˈstrʌkʃ(ə)n]                      | n. 说明,须知;教导
+interest                       | [ˈɪntrɪst]                           | n. 兴趣，趣味;利息
+interesting                    | [ˈɪntrɪstɪŋ]                         | a. 有趣的
+international                  | [ɪntəˈnæʃən(ə)l]                     | a. 国际的
+internet                       | [ˈɪntənet]                           | n. 互联网，英特网
+into                           | [ˈɪntʊ, ˈɪntə]                       | prep. 到…里;向内；变成
+introduce                      | [ɪntrəˈdjuːs; (US) -duːs]            | vt. 介绍
+invent                         | [ɪnˈvent]                            | vt. 发明，创造
+invention                      | [ɪnˈvenʃ(ə)n]                        | n. 发明，创造
+inventor                       | [ɪnˈventə(r)]                        | n. 发明者，创造者
+invite                         | [ɪnˈvaɪt]                            | vt. 邀请，招待
+is                             | [iz]                                 | v. 是
+island                         | [ˈaɪlənd]                            | n. 岛
+it                             | [ɪt]                                 | pron. 它
+its                            | [ɪts]                                | pron. 它的
+itself                         | [ɪtˈself]                            | pron. 它自己
+jacket                         | [ˈdʒækɪt]                            | n. 短上衣，夹克衫
+jam                            | [dʒæm]                               | n. 果酱；阻塞
+January                        | [ˈdʒænjʊərɪ; (US) ˈdʒænjʊerɪ]        | n. 1月
+Japan                          | [dʒæˈpæn]                            | n. 日本
+Japanese                       | [dʒæpəˈniːz]                         | a. 日本的，日本人的，日语的 n. 日本人，日语
+jeep                           | [dʒiːp]                              | n. 吉普车
+job                            | [dʒɔb]                               | n. （一份）工作
+join                           | [dʒɔɪn]                              | v. 参加,加入;连接;会合
+joke                           | [dʒəʊk]                              | n. 笑话
+journalist                     | [ˈdʒɜːnəlɪzt]                        | n. 记者，新闻工作者
+journey                        | [ˈdʒɜːnɪ]                            | n. 旅行，路程
+joy                            | [dʒɔɪ]                               | n. 欢乐，高兴，乐趣
+judge                          | [dʒʌdʒ]                              | n. 裁判；审判员；法官 vt. 判断，断定
+juice                          | [dʒuːs]                              | n. 汁、液
+July                           | [dʒʊˈlaɪ]                            | n. 7月
+jump                           | [dʒʌmp]                              | n. 跳跃；跳变 v. 跳跃；惊起；猛扑
+June                           | [dʒuːn]                              | n. 6月
+jungle                         | [ˈdʒʌŋɡ(ə)l]                         | n. 丛林，密林
+junior                         | [ˈdʒuːnɪə(r)]                        | a. 初级的；年少的
+just                           | [dʒʌst]                              | ad. 刚才；恰好；不过；仅 a. 公正的
+kangaroo                       | [kæŋɡəˈruː]                          | n. 大袋鼠
+keep (kept, kept)              | [kiːp]                               | v. 保持；保存；继续不断 vt. 培育，饲养
+key                            | [kiː]                                | n. 钥匙;答案;键;关键
+keyboard                       | [kiːbɔːd]                            | n. 键盘
+kick                           | [kɪk]                                | v.& n. 踢
+kid                            | [kɪd]                                | n. 小孩
+kill                           | [kɪl]                                | v. 杀死，弄死
+kilo                           | [ˈkiːləʊ]                            | n. 千克；千米
+kilogram                       | [ˈkɪləuɡræm]                         | n. 千克
+kilometre                      | ['kiləumi:tə(r)]                     | n. 千米（公里）
+kind                           | [kaɪnd]                              | n. 种;类 a. 善良,友好的
+kind-hearted                   | [kaɪnd- 'hɑ:tid]                     | a. 好心的
+king                           | [kɪŋ]                                | n. 国王
+kingdom                        | [ˈkɪŋdəm]                            | n. 王国
+kiss                           | [kɪs]                                | n.& vt. 吻，亲吻
+kitchen                        | [ˈkɪtʃɪn]                            | n. 厨房
+kite                           | [kaɪt]                               | n. 风筝
+knee                           | [niː]                                | n. 膝盖
+knife                          | [naɪf]                               | (复 knives) n. 小刀;匕首;刀片
+knock                          | [nɔk]                                | n.& v. 敲；打；击 
+know(knew,known)               | [nəʊ]                                | v. 知道，了解；认识；懂得
+knowledge                      | [ˈnɔlɪdʒ]                            | n. 知识，学问
+Korea                          | [kərɪə]                              | n.朝鲜；韩国
+Korean                         | [kərɪən]                             | n.朝鲜的；韩国的；韩国的人
+lab                            | [læb]                                | = laboratory n. 实验室
+ladder                         | [ˈlædə(r)]                           | n. 梯子
+lady                           | [ˈleɪdɪ]                             | n. 女士，夫人
+lake                           | [leɪk]                               | n. 湖
+lamp                           | [læmp]                               | n. 灯，油灯；光源
+land                           | [lænd]                               | n. 陆地,土地 v. 登岸(陆)降落
+language                       | [ˈlæŋɡwɪdʒ]                          | n. 语言
+lap                            | [læp]                                | n. (人坐时)膝部,(跑道的)一圈
+large                          | [lɑːdʒ]                              | a. 大的；巨大的
+last                           | [lɑːst; (US) læst]                   | a. 最后的 ad. 最后地 n. 最后 v. 持续
+late                           | [leɪt]                               | a. 晚的,迟的 ad. 晚地,迟地
+lately                         | [ˈleɪtlɪ]                            | ad. 最近，不久前
+later                          | [ˈleɪtə(r)]                          | a. 晚些的，迟些的
+laugh                          | [lɑːf]                               | n.& v. 笑，大笑；嘲笑
+law                            | [lɔː]                                | n. 法律，法令；定律
+lay (laid, laid)               | [leɪ]                                | vt. 放，搁
+lazy                           | [ˈleɪzɪ]                             | a. 懒惰的
+lead (led, led)                | [liːd]                               | v. 领导，带领 n. 铅
+leader                         | [ˈliːdə(r)]                          | n. 领袖，领导人
+leaf (复 leaves)               | [liːf]                               | n. （树，菜）叶
+league                         | [liːɡ]                               | n. 联盟，社团
+learn (learnt, learnt；-ed -ed)| [lɜːn]                               | vt. 学，学习，学会
+least                          | [liːst]                              | n. 最少，最少量
+leather                        | [ˈleðə(r)]                           | n. 皮革
+leave (left, left)             | [liːv]                               | v. 离开;把…留下，剩下
+left                           | [left]                               | a. 左边的 ad. 向左 n. 左,左边
+leg                            | [leɡ]                                | n. 腿；腿脚；支柱
+lend (lent, lent)              | [lend]                               | vt. 借(出),把…借给
+less（little的比较级）           | [les]                                | a.& ad. 少于,小于
+lesson                         | [ˈles(ə)n]                           | n. 课；功课；教训
+let (let, let)                 | [let]                                | vt. 让
+letter                         | [ˈletə(r)]                           | n. 信；字母
+librarian                      | [laiˈbreəriən]                       | n. 图书管理员；（西方的）图书馆馆长
+library                        | [ˈlaibrəri; (US) ˈlaibreri]          | n. 图书馆，图书室
+license                        | [ˈlaisəns]                           | n. 执照，许可证
+lie (lay, lain)                | [lai]                                | v. 躺;卧;平放;位于n.& vi.(lied,lied) 说谎
+life (复lives)                 | [laif]                               | n. 生命；生涯；生活；人生；生物
+lifetime                       | [ˈlaiftaim]                          | n. 一生，终生
+lift                           | [lift]                               | v. 举起，抬起；（云、烟等）消散 n. （英）电梯
+light                          | [laɪt]                               | n. 光，光亮；灯，灯光 vt. 点（火），点燃 a. 明亮的；轻的；浅色的
+like                           | [laɪk]                               | prep. 像，跟…一样 vt. 喜欢，喜爱
+line                           | [laɪn]                               | n. 绳索，线，排，行，线路 v. 画线于，（使）成行
+lion                           | [ˈlaɪən]                             | n. 狮子
+lip                            | [lɪp]                                | n. 嘴唇
+list                           | [lɪst]                               | n. 一览表，清单
+listen                         | [ˈlɪs(ə)n]                           | vi. 听,仔细听
+litter                         | [ˈlɪtə(r)]                           | v. 乱丢杂物
+little (less, least)           | [ˈlɪt(ə)l]                           | a. 小的,少的 ad. 很少地, 稍许 n. 没有多少
+live                           | [lɪv]                                | vi. 生活;居住;活着 a. 活的,活着的;现场（直播）的
+lively                         | [ˈlaɪvlɪ]                            | a. 活泼的;充满生气的
+living                         | [ˈlɪvɪŋ]                             | a. 活着的 n. 生计
+lock                           | [lɔk]                                | n. 锁 vt. 锁，锁上
+London                         | [ˈlʌnd(ə)n]                          | n. 伦敦
+lonely                         | [ˈləʊnlɪ]                            | a. 孤独的，寂寞的
+long                           | [lɔŋ; (US) lɔːŋ]                     | a. 长的，远 ad. 长久
+look                           | [lʊk]                                | n. 看，瞧 v. 看，观看 v. link 看起来
+lose (lost, lost)              | [luːz]                               | vt. 失去，丢失
+lot                            | [lɔt]                                | n. 许多，好些
+loud                           | [laʊd]                               | a. 大声的
+loudly                         | [laʊdlɪ]                             | ad. 大声地
+loudspeaker                    | [laʊdˈspiːkə(r)]                     | n. 扬声器，喇叭
+love                           | [lʌv]                                | n.& vt. 爱；热爱;很喜欢
+lovely                         | [ˈlʌvlɪ]                             | a. 美好的，可爱的
+low                            | [ləʊ]                                | a.& ad. 低；矮
+luck                           | [lʌk]                                | n. 运气，好运
+lucky                          | [ˈlʌkɪ]                              | a. 运气好，侥幸
+lunch                          | [lʌntʃ]                              | n. 午餐，午饭
+machine                        | [məˈʃiːn]                            | n. 机器
+madam/ madame                  | [ˈmædəm]                             | n. 夫人,女士
+magazine                       | [mæɡəˈziːn]                          | n. 杂志
+magic                          | [ˈmædʒɪk]                            | a. 有魔力的
+mail                           | [meɪl]                               | n. 邮政,邮递 v. (美)邮寄
+main                           | [meɪn]                               | a. 主要的
+mainland                       | [ˈmeɪnlənd]                          | n. 大陆
+make (made,made)               | [meɪk]                               | vt. 制造,做;使得
+man (复men)                    | [mæn]                                | n. 成年男人;人类
+manage                         | [ˈmænɪdʒ]                            | v. 管理；设法对付
+manager                        | [ˈmænɪdʒə(r)]                        | n. 经理
+man-made                       | [mæn- meɪd]                          | a. 人造的，人工的
+many (more, most)              | [ˈmenɪ]                              | pron. 许多人（或物）a. 许多的
+map                            | [mæp]                                | n. 地图
+March                          | [mɑːtʃ]                              | n. 3月
+mark                           | [mɑːk]                               | n. 标记 vt. 标明,作记号于
+market                         | [ˈmɑːkɪt]                            | n. 市场，集市
+marry                          | [ˈmærɪ]                              | v.（使）成婚，结婚
+match                          | [mætʃ]                               | vt. 使相配，使成对 n. 比赛，竞赛 n. 火柴
+mathematics =math / maths      | [mæθəˈmætɪks]                        | n.（常作单数用）数学, (英美口语) 数学
+matter                         | [ˈmætə(r)]                           | n. 要紧事，要紧, 事情；问题 vi. 要紧，有重大关系
+May                            | [meɪ]                                | n. 5月
+maybe                          | [ˈmeɪbiː]                            | ad. 可能，大概，也许
+me                             | [miː, mɪ]                            | pron. 我（宾格）
+meal                           | [miːl]                               | n. 一餐（饭） 
+mean(meant,meant)              | [miːn]                               | vt. 意思,意指
+meaning                        | [ˈmiːnɪŋ]                            | n. 意思，含意
+means                          | [miːnz]                              | n. 方法，手段；财产
+meat                           | [miːt]                               | n.（猪、牛、羊等的）肉
+meet (met, met)                | [miːt]                               | vt./ n. 遇见，见到 会；集会
+meeting                        | [ˈmiːtɪŋ]                            | n. 会,集会,会见,汇合点
+melon                          | [ˈmelən]                             | n.（甜）瓜；瓜状物
+member                         | [ˈmembə(r)]                          | n. 成员，会员
+memory                         | [ˈmemərɪ]                            | n. 回忆，记忆
+mend                           | [mend]                               | v. 修理，修补
+mention                        | [ˈmenʃ(ə)n]                          | n. 提及；记载 vt. 提到，说起
+menu                           | [ˈmenjuː]                            | n. 菜单
+merry                          | [ˈmerɪ]                              | a. 高兴的，愉快的
+message                        | [ˈmesɪdʒ]                            | n. 消息，音信
+metal                          | [ˈmet(ə)l]                           | n. 金属 a. 金属制成的
+metre (美meter)                | ['mi:tə]                             | n. 米，公尺
+mid-autumn                     | [mɪd- ˈɔːtəm]                        | n. 中秋
+middle                         | [ˈmɪd(ə)l]                           | n. 中间;当中;中级的
+Middle East                    | [ˈmɪd(ə)liːst]                       | n. 中东
+midnight                       | [ˈmɪdnaɪt]                           | n. 午夜
+might                          | [maɪt]                               | v. aux. (may的过去式，助动词) 可能，也许，或许
+mild                           | [maɪld]                              | a. 温和,暖和的,凉爽的
+mile                           | [maɪl]                               | n. 英里
+milk                           | [mɪlk]                               | n. 牛奶 vt. 挤奶
+million                        | [ˈmɪlɪən]                            | num. 百万 n. 百万个（人或物）
+mind                           | [maɪnd]                              | n. 思想,想法 v.介意,关心
+mine                           | [maɪn]                               | n. 矿藏,矿山 vt. 开采(矿物)pron. 我的
+minibus                        | [ˈmɪnɪbʌs]                           | n. 小型公共汽车
+minus                          | [ˈmaɪnəs]                            | prep. & a.负的，减去的
+minute                         | [ˈmɪnɪt]                             | n. 分钟;一会儿，瞬间
+mirror                         | [ˈmɪrə(r)]                           | n. 镜子
+miss                           | [mɪs]                                | vt. 失去，错过，缺
+Miss.                          | [mɪs]                                | n. 小姐,女士(称呼未婚妇女)
+mist                           | [mɪst]                               | n. 雾
+mistake (mistook, mistaken)    | [mɪsˈteɪk]                           | n. 错误 vt. 弄错
+mobile                         | [ˈməubaɪl; (US) məubl]               | a. 活动的，可移动的
+model                          | [ˈmɔd(ə)l]                           | n. 模型,原形,范例,模范
+modern                         | [ˈmɔd(ə)n]                           | a. 现代的
+Mom =Mum                       | [mɔm]                                | n. 妈妈
+moment                         | [ˈməumənt]                           | n. 片刻，瞬间
+mommy = mummy                  | [ˈmʌmɪ]                              | n. 妈妈（美）
+Monday                         | [ˈmʌndeɪ, ˈmʌndɪ]                    | n. 星期一
+money                          | [ˈmʌnɪ]                              | n. 钱；货币
+monitor                        | [ˈmɔnɪtə(r)]                         | n.（班级内的）班长；纠察生；监视器
+monkey                         | [ˈmʌŋkɪ]                             | n. 猴子
+month                          | [mʌnθ]                               | n. 月，月份
+monument                       | [ˈmɔnjumənt]                         | n. 纪念碑，纪念物
+moon                           | [muːn]                               | n. 月球；月光；月状物
+mooncake                       | [muːnkeɪk]                           | n. 月饼
+more（much或many的比较级）     | [mɔː(r)]                             | a./ ad. 另外的;较多的;而且;更 n. 更多的量
+morning                        | [ˈmɔːnɪŋ]                            | n. 早晨，上午
+most (much或many的最高级)      | [məʊst; (US) mɔːst]                  | a. & ad. 最多 n. 大部分,大多数
+mother                         | [ˈmʌðə(r)]                           | n. 母亲
+motor                          | [ˈməʊtə(r)]                          | n. 发动机，马达
+motorbike                      | [ˈməʊtəbaɪk]                         | n. 摩托车
+motorcycle                     | ['məʊtəsaikl]                        | n. 摩托车
+mountain(s)                    | [ˈmaʊntɪn(z)]                        | n. 山，山脉
+mouse (复mice)                 | [maʊs]                               | n. 鼠，耗子；（计算机）鼠标
+mouth                          | [maʊθ]                               | n. 嘴，口
+move                           | [muːv]                               | v. 移动，搬动，搬家
+movement                       | [ˈmuːvmənt]                          | n. 运动，活动
+movie                          | [ˈmuːvɪ]                             | n.（口语）电影
+Mr. (mister)                   | [ˈmɪstə(r)]                          | n. 先生（用于姓名前）
+Mrs. (mistress)                | [ˈmɪsɪz]                             | n. 夫人, 太太（称呼已婚妇女）
+Ms.                            | [mɪz]                                | n. 女士(用在婚姻状况不明的女子姓名前)
+much (more，most)              | [mʌtʃ]                               | a./ ad. 许多，大量，非常，更加
+multiply                       | [ˈmʌltɪplaɪ]                         | vt. 乘；使相乘
+murder                         | [ˈmɜːdə(r)]                          | vt. 谋杀
+museum                         | [mjuːˈzɪəm]                          | n. 博物馆，博物院
+music                          | [ˈmjuːzɪk]                           | n. 音乐，乐曲
+must                           | [mʌst]                               | v. 必须,应当;必定是
+mutton                         | [ˈmʌt(ə)n]                           | n. 羊肉
+my                             | [maɪ]                                | pron. 我的
+myself                         | [maɪˈself]                           | pron. 我自己
+nail                           | [neɪl]                               | n. 钉，钉子
+name                           | [neɪm]                               | n. 名字,姓名,名称 vt. 命名,名叫
+narrow                         | [ˈnærəʊ]                             | a. 狭窄的
+nation                         | [ˈneɪʃ(ə)n]                          | n. 民族，国家
+national                       | [ˈnæʃən(ə)l]                         | a. 国家的,全国性的，民族的
+natural                        | [ˈnætʃər(ə)l]                        | a. 自然的
+nature                         | [ˈneɪtʃə(r)]                         | n. 自然, 性质，种类
+near                           | [nɪə(r)]                             | a. 近的 ad. 附近，邻近 prep. 在…附近，靠近
+nearby                         | [ˈnɪəbaɪ]                            | a. 附近的
+nearly                         | [ˈnɪəlɪ]                             | ad. 将近，几乎
+neat                           | [niːt]                               | a. 整洁的；灵巧的
+necessary                      | [ˈnesisərɪ; (US) ˈnesəserɪ]          | a. 必需的，必要的
+neck                           | [nek]                                | n. 颈，脖子
+necklace                       | [ˈneklɪs]                            | n. 项链
+necktie                        | [ˈnektaɪ]                            | n. 领带，领花
+need                           | [niːd]                               | n. 需要,需求 aux.& v. 需要,必须
+needle                         | [niːd(ə)l]                           | n. 针
+neighbour (美neighbor)         | [ˈneibə(r)]                          | n. 邻居，邻人
+neighbourhood (美neighborhood) | ['neibəhud]                          | n. 四邻；邻近地区
+neither                        | [ˈnaɪðə(r), ˈniːðə(r)]               | a.（两者）都不;也不
+nervous                        | [ˈnəːvəs]                            | a. 紧张不安的
+nest                           | [nest]                               | n. 巢；窝
+net                            | [net]                                | n. 网
+network                        | [ˈnetwəːk]                           | n. 网络，网状系统
+never                          | [ˈnevə(r)]                           | ad. 决不，从来没有
+new                            | [njuː; (US) nuː]                     | a. 新的；新鲜的
+news                           | [njuːz; (US) nuːz]                   | n. 新闻，消息
+newspaper                      | [njuːzˈpeɪpə(r); (US) nuːzˈpeɪpə(r)] | n. 报纸
+next                           | [nekst]                              | a. 下一个的,紧挨着的，隔壁的 ad. 随后，然后，下一步
+nice                           | [naɪs]                               | a. 令人愉快;好的,漂亮的
+niece                          | [niːs]                               | n. 侄女，甥女
+night                          | [naɪt]                               | n. 夜；夜间
+night-club                     | [naɪt-klʌb]                          | n. 夜总会
+nine                           | [naɪn]                               | num. 九
+nineteen                       | [naɪnˈtiːn]                          | num. 十九
+ninety                         | [ˈnaɪntɪ]                            | num. 九十
+ninth                          | [naɪnθ]                              | num. 第九
+no                             | [nəʊ]                                | ad. 不,不是 a. 没有,无,不
+No.(缩) = number               | [ˈnʌmbə(r)]                          | n. 数字;号码
+nobody                         | [ˈnəʊbədɪ]                           | n. 渺小人物 pron. 没有人，谁也不
+nod                            | [nɔd]                                | vi. 点头
+noise                          | [nɔɪz]                               | n. 声音，噪声，喧闹声
+noisily                        | ['nɔɪzɪlɪ]                           | ad. 喧闹地
+noisy                          | [ˈnɔɪzɪ]                             | a. 喧闹的，嘈杂的
+none                           | [nʌn]                                | pron. 无任何东西, 无一人
+noodle                         | [ˈnuːd(ə)l]                          | n. 面条
+noon                           | [nuːn]                               | n. 中午，正午
+nor                            | [nɔː(r)]                             | conj. 也不
+normal                         | [ˈnɔːm(ə)l]                          | n.& a. 正常的（状态）
+north                          | [nɔːθ]                               | a. 北的;朝北的 ad. 向（在,从）北方 n. 北;北方;北部
+northeast                      | [nɔ:θ'i:st]                          | n. 东北（部）
+northern                       | [ˈnɔːð(ə)n]                          | a. 北方的，北部的
+northwest                      | [nɔ:θ'west]                          | n. 西北
+nose                           | [nəʊz]                               | n. 鼻子
+not                            | [nɔt]                                | ad. 不，没
+note                           | [nəʊt]                               | n. 便条，笔记，注释；钞票，音调
+notebook                       | [ˈnəʊtbʊk]                           | n. 笔记簿
+nothing                        | [ˈnʌθɪŋ]                             | n. 没有东西,没有什么
+notice                         | [ˈnəʊtɪs]                            | n. 布告，通告；注意 vt. 注意，注意到
+novel                          | [ˈnɔv(ə)l]                           | n.（长篇）小说
+November                       | [nəʊˈvembə(r)]                       | n. 11月
+now                            | [naʊ]                                | ad. 现在
+nowhere                        | [ˈnəʊweə(r); (US) ˈnəʊhweər]         | ad. 任何地方都不,无处
+number                         | [ˈnʌmbə(r)]                          | n. 数,数字,号码,数量
+nurse                          | [nəːs]                               | n. 护士；保姆；保育员
+obey                           | [əˈbeɪ]                              | v. 服从，顺从，听从
+object                         | [ˈɔbdʒɪkt]                           | n. 物，物体；宾语
+ocean                          | [ˈəʊʃ(ə)n]                           | n. 海洋
+Oceania                        |                                      | n. 大洋洲
+o'clock                        | [əʃklɔk]                             | n. 点钟
+October                        | [ɔkˈtəʊbə(r)]                        | n. 10月
+of                             | [ɔv, əv; (US) ˈɔf]                   | prep. ….的
+off                            | [ɔːf]                                | prep. 离开,脱离,（走）开
+offer                          | [ˈɔfə(r)]                            | n.& vt. 提供；建议
+office                         | [ˈɔfɪs]                              | n. 办公室
+often                          | [ˈɔf(ə)n; (US) ˈɔːfn]                | ad. 经常，常常
+oh                             | [əʊ]                                 | int. 哦！啊！
+oil                            | [ɔɪl]                                | n. 油
+OK                             | [əʊˈkeɪ]                             | ad.（口语）好,对,不错
+old                            | [əʊld]                               | a. 老的，旧的
+Olympic(s)                     | [əʊˈlɪmpɪk]                          | a. & n. 奥林匹克
+Olympic Games                  | [əʊˈlɪmpɪk ɡeɪms]                    | n. 奥运会
+on                             | [ɔn]                                 | prep. 在…上（时），关于 ad. 接通；进行下去；（电灯）开
+once                           | [wʌns]                               | n.& ad. 一次,一度,从前 conj. 一旦
+one                            | [wʌn]                                | pron. 一（个，只…）
+oneself                        | [wʌnˈself]                           | pron. 自己；自身
+onion                          | [ˈʌnjən]                             | n. 洋葱；洋葱头
+only                           | [ˈəʊnlɪ]                             | a. 惟一的，仅有的 ad. 仅仅，只，才
+onto                           | [ˈɔntʊ]                              | prep. 到…的上面
+open                           | [ˈəʊpən]                             | a. 开着的,开的 vt. 开,打开
+opera                          | [ˈɔpərə]                             | n. 歌剧
+operate                        | [ˈɔpəreɪt]                           | v. 做手术，运转；实施，负责, 经营，管理
+opinion                        | [əˈpɪnjən]                           | n. 看法，见解
+or                             | [ə(r), ɔː(r)]                        | conj. 或；就是；否则
+orange                         | [ˈɔrɪndʒ; (US) ˈɔːr-]                | n. 橘子，橙子，橘汁 a. 橘色的，橙色的
+order                          | [ˈɔːdə(r)]                           | vt. 定购，定货；点菜n. 顺序
+ordinary                       | [ˈɔːdɪnərɪ; (US) ˈɔːrdənerɪ]         | a. 普通的，平常的
+other                          | [ˈʌðə(r)]                            | pron. 别人，别的东西 a. 别的,另外的
+our                            | [ˈaʊə(r)]                            | pron. 我们的
+ours                           | [ˈaʊəz]                              | pron. 我们的
+ourselves                      | [aʊəˈselvz]                          | pron. 我们自己
+out                            | [aʊt]                                | ad. 出外;在外,向外;熄
+outdoors                       | [aʊtˈdɔːz]                           | ad. 在户外, 在野外
+outside                        | [aʊtˈsaɪd]                           | n. 外面 ad. 在外面；向外面 prep. 在…外面
+over                           | [ˈəʊvə(r)]                           | prep. 在…上方,越过,遍及 ad. 翻倒,遍布,越过,结束
+overcoat                       | [ˈəʊvəkəʊt]                          | n. 大衣
+own                            | [əʊn]                                | a. 自己的 v. 拥有,所有
+owner                          | [ˈəʊnə(r)]                           | n. 物主，所有人
+Pacific                        | [pəˈsɪfɪk]                           | a. 太平洋的
+the Pacific Ocean              | [ðə pəˈsɪfɪkˈəʊʃ (ə)n]               | 太平洋
+pack                           | [pæk]                                | n. 包,捆;（猎犬、野兽的）一群 v. (为运输或储存而)打包
+packet                         | [ˈpækɪt]                             | n. 小包裹，袋
+page                           | [peɪdʒ]                              | n. 页，页码
+pain                           | [peɪn]                               | n. 疼痛，疼
+painful                        | [ˈpeɪnfʊl]                           | a. 使痛的，使痛苦的
+paint                          | [peɪnt]                              | n. 油漆 vt. 油漆,粉刷,绘画
+painter                        | [ˈpeɪntə(r)]                         | n. 绘画者,（油）画家
+painting                       | [ˈpeɪntɪŋ]                           | n. 油画，水彩画
+pair                           | [peə(r)]                             | n. 一双，一对
+palace                         | [ˈpælɪs]                             | n. 宫，宫殿
+pale                           | [peɪl]                               | a. 苍白的，灰白的
+pan                            | [pæn]                                | n. 平底锅
+panda                          | [ˈpændə]                             | n. 熊猫
+paper                          | [ˈpeɪpə(r)]                          | n. 纸；报纸
+pardon                         | [ˈpɑːd(ə)n]                          | n. 原谅,宽恕,对不起
+parent                         | [ˈpeərənt]                           | n. 父(母)，双亲
+park                           | [pɑːk]                               | n. 公园 vt. 停放（汽车）
+parking                        | [ˈpɑːkɪŋ]                            | n. 停车
+parrot                         | [ˈpærət]                             | n. 鹦鹉
+part                           | [pɑːt]                               | n. 部分；角色；部件；零件 a. 局部的；部分的
+party                          | [ˈpɑːtɪ]                             | n. 聚会，晚会；党派
+pass                           | [pɑːs; (US) pæs]                     | vt. 传，递；经过；通过
+passage                        | [ˈpæsɪdʒ]                            | n.（文章等的）一节，一段；通道；走廊
+passenger                      | [ˈpæsɪndʒə(r)]                       | n. 乘客，旅客
+passport                       | [ˈpɑːspɔːt; (US) ˈpæspɔːt]           | n. 护照
+past                           | [pɑːst; (US) pæst]                   | ad. 过 n. 过去，昔日，往事 prep. 过…，走过某处
+path                           | [pɑːθ; (US) pæθ]                     | n. 小道，小径
+patient                        | [ˈpeɪʃ(ə)nt]                         | n. 病人
+pause                          | [pɔːz]                               | n.& vi. 中止，暂停；停止
+pay                            | [peɪ]                                | (paid, paid) v. 付钱，给…报酬 n. 工资
+P.C.(缩) =personal computer    | [piːsiː]                             | 个人电脑
+P.E.(缩) =physical education   | [piːiː]                              | 体育
+pea                            | [piː]                                | n. 豌豆
+peace                          | [piːs]                               | n. 和平
+pear                           | [peə(r)]                             | n. 梨子，梨树
+pen                            | [pen]                                | n. 钢笔，笔
+pencil                         | [ˈpens(ə)l]                          | n. 铅笔
+pencil-box                     | [ˈpens(ə)l -bɔks]                    | n. 铅笔盒
+penny                          | [ˈpenɪ]                              | (英复pence) n.（英）便士；美分
+people                         | [ˈpiːp(ə)l]                          | n. 人，人们；人民
+pepper                         | [ˈpepə(r)]                           | n. 胡椒粉
+performance                    | [pəˈfɔːməns]                         | n. 演出，表演
+perhaps                        | [pəˈhæps]                            | ad. 可能，或
+permit                         | [pəˈmɪt]                             | vt. 许可,允许;执照 n. 许可证
+person                         | [ˈpɜːs(ə)n]                          | n. 人
+personal                       | [ˈpɜːsən(ə)l]                        | a. 个人的，私人的
+pet                            | [pet]                                | n. 宠物，爱畜
+phone = telephone              | [fəʊn]                               | v. 打电话 n. 电话，电话机
+photo =photograph              | [ˈfəʊtəʊ]                            | n. 照片
+photograph                     | [ˈfəʊtəʊɡrɑːf; (US) -ɡræf]           | n. 照片
+phrase                         | [freɪz]                              | n. 短语；习惯用语
+physicist                      | [ˈfɪzɪsɪst]                          | n. 物理学家
+physics                        | [ˈfɪzɪks]                            | n. 物理（学）
+pianist                        | [ˈpɪənist]                           | n. 钢琴家
+piano                          | [pɪˈænəʊ]                            | n. 钢琴
+pick                           | [pɪk]                                | v. 拾起，采集；挑选
+picnic                         | [ˈpɪknɪk]                            | n.& v. 野餐
+picture                        | [ˈpɪktʃə(r)]                         | n. 图片，画片，照片
+pie                            | [paɪ]                                | n. 甜馅饼
+piece                          | [pɪs]                                | n. 一块（片，张，件…）
+pig                            | [pɪg]                                | n. 猪
+pile                           | [paɪl]                               | n./v. 堆
+pill                           | [pɪl]                                | n. 药丸，药片
+pilot                          | [ˈpaɪlət]                            | n. 飞行员
+ping-pong                      | [pɪŋ-pɔɡ]                            | n. 乒乓球
+pink                           | [pɪŋk]                               | a. 粉红色的
+pioneer                        | [paɪəˈnɪə(r)]                        | n. 先锋，开拓者
+pity                           | [ˈpɪtɪ]                              | n. 怜悯，同情
+place                          | [pleɪs]                              | n. 地方，处所 v. 放置，安置，安排
+plan                           | [plæn]                               | n.& v. 计划，打算
+plane                          | [pleɪn]                              | n. 飞机
+planet                         | [ˈplænɪt]                            | n. 行星
+plant                          | [plɑːnt; (US) ˈplænt]                | vt. 种植，播种 n. 植物
+plastic                        | [ˈplæstɪk]                           | a. 塑料的
+plate                          | [pleɪt]                              | n. 板；片；牌；盘子；盆子
+play                           | [pleɪ]                               | v. 玩；打（球）；游戏；播放 n. 玩耍，戏剧
+player                         | [ˈpleɪə(r)]                          | n. 比赛者，选手
+playground                     | [ˈpleɪgraʊnd]                        | n. 操场，运动场
+pleasant                       | [ˈplezənt]                           | a. 令人愉快的，舒适的
+please                         | [pliːz]                              | v. 请,使人高兴,使人满意
+pleased                        | [pliːzd]                             | a. 高兴的
+pleasure                       | [ˈpleʒə]                             | n. 高兴，愉快
+plenty                         | [plenti]                             | n. 充足，大量
+plus                           | [plʌs]                               | prep. 加，加上
+p.m./pm, P.M. /PM              | [piːem]                              | n. 下午,午后
+pocket                         | [ˈpɔkɪt]                             | n.（衣服的）口袋
+point                          | [pɔɪnt]                              | v. 指，指向 n. 点；分数
+police                         | [pəˈliːs]                            | n. 警察，警务人员
+policeman (复-men)             | [pəˈliːsmən]                         | n. 警察,巡警 policewoman ( -women) n. 女警察
+polite                         | [pəˈlaɪt]                            | a. 有礼貌的,有教养的
+politics                       | [ˈpɔlɪtɪks]                          | n. 政治
+pollute                        | [pəˈluːt]                            | vt. 污染
+pool                           | [puːl]                               | n. 水塘，水池
+poor                           | [pʊə(r)]                             | a. 贫穷；可怜；不好的,差的
+pop = popular                  | [pɔp]                                | a. (口语) （音乐、艺术等）大众的，通俗的
+popular                        | [ˈpɔpjʊlə(r)]                        | a. 流行,大众,受欢迎的
+population                     | [pɔpjʊˈleɪʃ(ə)n]                     | n. 人口，人数
+pork                           | [pɔːk]                               | n. 猪肉
+porridge                       | [ˈpɔrɪdʒ; (US) ˈpɔːrɪdʒ]             | n. 稀饭，粥
+port                           | [pɔːt]                               | n. 港口，码头
+possible                       | [ˈpɔsɪb(ə)l]                         | a. 可能的
+post                           | [pəʊst]                              | n. 邮政，邮寄，邮件 v. 投寄；邮寄
+postage                        | [ˈpəʊstɪdʒ]                          | n. 邮费
+postbox                        | [ˈpəʊstbɔks]                         | n. 邮箱
+postcard                       | [ˈpəʊstkɑːd]                         | n. 明信片
+postcode                       | [ˈpəʊstkəʊd]                         | n. （英）邮政编码
+postman                        | [ˈpəʊstmən]                          | n. 邮递员
+potato                         | [pəʊteɪtəʊ]                          | n. 土豆，马铃薯
+potential                      | [pəʊtenʃ (ə)l]                       | a. 潜在的，可能的
+pound                          | [paund]                              | n. 磅；英镑
+pour                           | [paʊ(r)]                             | vi. 倾泻，不断流出
+practice(s)e                   | [ˈpræktɪs]                           | n. 练习
+praise                         | [preɪz]                              | n.& vt. 赞扬，表扬
+prefer                         | [prɪˈfəː (r)]                        | vt.宁愿（选择）,更喜欢
+prepare                        | [prɪˈpeə(r)]                         | vt. 准备,预备,调制,配制
+present                        | [ˈprez(ə)nt]                         | a. 出现的，出席的 n. 礼物，赠品 vt. 呈奉，奉送
+press                          | [pres]                               | vt. 压,按 n. 新闻界,出版社
+pretty                         | [ˈprɪtɪ]                             | a. 漂亮的，俊俏的
+prevent                        | [prɪˈvent]                           | vt. 防止, 预防
+price                          | [praɪs]                              | n. 价格，价钱
+pride                          | [praɪd]                              | n. 自豪，骄傲
+print                          | [prɪnt]                              | vt. 印刷
+prize                          | [praɪz]                              | n. 奖赏，奖品
+probable                       | [ˈprɔbəb(ə)l]                        | a. 很可能,很有希望的
+probably                       | [ˈprɔbəb(ə)lɪ]                       | ad. 很可能，大概
+problem                        | [ˈprɔbləm]                           | n. 问题，难题
+produce                        | [prəˈdjuːs; (US) -ˈduːs]             | vt. 生产；制造
+professor                      | [prəˈfesə(r)]                        | n. 教授
+programme (美program)          | [ˈprəʊɡræm]                          | n. 节目；项目
+progress                       | [ˈprəʊɡres; (US) ˈprɔɡres]           | n. 进步,上进 vi. 进展,进行
+promise                        | [ˈprɔmɪs]                            | n.& vi. 答应，允诺
+pronounce                      | [prəˈnaʊns]                          | vt. 发音
+pronunciation                  | [prənʌnsɪˈeɪʃ(ə)n]                   | n. 发音
+proper                         | [ˈprɔpə(r)]                          | a. 恰当的，合适的
+protect                        | [prəˈtekt]                           | vt. 保护
+proud                          | [praʊd]                              | a. 自豪的；骄傲的
+provide                        | [prəˈvaɪd]                           | vt. 提供
+province                       | [ˈprɔvɪns]                           | n. 省
+public                         | [ˈpʌblɪk]                            | a. 公共,公众的 n. 公众
+pull                           | [pʊl]                                | 拉，拖 n. 拉力，引力
+pupil                          | [ˈpjuːpɪl]                           | n.（小）学生
+purple                         | [ˈpɜːp(ə)l]                          | n. / a. 紫色
+purse                          | [pɜːs]                               | n. 钱包
+push                           | [pʊʃ]                                | n.& v. 推
+put (put, put)                 | [pʊt]                                | vt. 放，摆
+pyramid                        | [pɪrəmɪd]                            | n.(古埃及)金字塔
+quarrel                        | [ˈkwɔrəl; (US) ˈkwɔːrəl]             | vi. 争吵，吵架
+quarter                        | [ˈkwɔːtə(r)]                         | n. 四分之一，一刻钟
+queen                          | [kwiːn]                              | n. 皇后，女王
+question                       | [ˈkwestʃ(ə)n]                        | vt. 询问 n. 问题
+queue                          | [kjuː]                               | n. 行列，长队
+quick                          | [kwɪk]                               | a. 快；敏捷的；急剧的
+quiet                          | [ˈkwaɪət]                            | a. 安静的；寂静的
+quilt                          | [kwɪlt]                              | n. 被子；被状物
+quit                           | [kwɪt]                               | v. 离任，离校，戒掉
+quite                          | [kwaɪt]                              | ad. 完全，十分
+quiz                           | [kwɪz]                               | n. 测验，小型考试
+rabbit                         | [ˈræbɪt]                             | n. 兔，家兔
+race                           | [reɪs]                               | n. 种族，民族 v.（速度）竞赛，比赛 n. 赛跑，竞赛
+radio                          | [reɪdɪəʊ]                            | n. 无线电，收音机
+rail                           | [reɪl]                               | n. 铁路
+railway                        | [ˈreɪlweɪ]                           | n. 铁路；铁道
+rain                           | [reɪn]                               | n. 雨，雨水 vi. 下雨
+raincoat                       | [ˈreɪnkəʊt]                          | n. 雨衣
+rainy                          | [ˈreɪnɪ]                             | a. 下雨的；多雨的
+raise                          | [reɪz]                               | vt. 使升高；饲养
+rat                            | [ræt]                                | n. 老鼠
+rather                         | [ˈrɑːðə; (US) ˈræðər]                | ad. 相当，宁可
+reach                          | [riːtʃ]                              | v. 到达,伸手(脚)够到
+read (read, read)              | [riːd]                               | v. 读；朗读
+ready                          | [ˈredɪ]                              | a. 准备好的
+real                           | [riːl]                               | a. 真实的，确实的
+realise (美realize)            | [ˈrɪəlaɪz]                           | vt. 认识到,实现
+really v                       | [ˈrɪəlɪ]                             | ad. 真正地；到底；确实
+reason                         | [ˈriːz(ə)n]                          | n. 理由,原因
+receive                        | [rɪˈsiːv]                            | v. 收到，得到
+recent                         | [ˈriːsənt]                           | a. 近来的，最近的
+record                         | [ˈrekɔːd; (US) ˈrekərd]              | n. 记录；唱片
+recycle                        | [riːˈsaɪk(ə)l]                       | vt. 回收；再循环
+red                            | [red]                                | n. 红色 a. 红色的
+refuse                         | [rɪˈfjuːz]                           | vi. 拒绝，不愿
+regard                         | [rɪˈɡɑːd]                            | v. 把…看作
+regret                         | [rɪˈɡret]                            | n./ vt. 可惜,遗憾;痛惜;哀悼
+regulation                     | [reɡjʊˈleɪʃ(ə)n]                     | n. 规则，规章
+relax                          | [rɪˈlæks]                            | v.（使）放松，轻松
+relay                          | [ˈriːleɪ]                            | n. 接力，接替人，中转 v. 接替，补充；转运
+remain                         | [rɪˈmeɪn]                            | vt. 余下,留下 vi. 保持,仍是
+remember                       | [rɪˈmembə(r)]                        | v. 记得，想起
+rent                           | [rent]                               | n.& v. 租金
+repair                         | [rɪˈpeə(r)]                          | n.& vt. 修理；修补
+repeat                         | [rɪˈpiːt]                            | vt. 重说，重做
+reply                          | [rɪˈplaɪ]                            | n. 回答，答复
+report                         | [rɪˈpɔːt]                            | n.& v. 报道，报告
+research                       | [rɪˈsɜːtʃ]                           | n. 研究，调查
+rest                           | [rest]                               | n. 休息；剩余的部分，其余的人（物） vi. 休息，歇息
+restaurant                     | [ˈrestərɔnt; (US) ˈrestərənt]        | n. 饭馆, 饭店
+result                         | [rɪˈzʌlt]                            | n. 结果，效果
+return                         | [rɪˈtɜːn]                            | v. 归还
+review                         | [rɪˈvjuː]                            | vt. 重新调查；回顾；复习 n. 复查；复习；评论
+rice                           | [raɪs]                               | n. 稻米；米饭
+rich                           | [rɪtʃ]                               | a. 富裕的，有钱的
+riddle                         | [ˈrɪd(ə)l]                           | n. 谜(语)
+ride (rode, ridden)            | [raɪd]                               | v. 骑（马、自行车）；乘车 n. 乘车旅行
+right                          | [raɪt]                               | n. 权利 a. 对,正确的 ad. 正确地,恰恰,完全地 a. 右,右边的
+ring (rang, rung)              | [rɪŋ]                                | v.（钟、铃等）响；打电话 n. 铃声 n. 环形物（如环、圈、戒指等）
+rise (rose, risen)             | [raɪz]                               | vi. 上升，上涨
+river                          | [ˈrɪvə(r)]                           | n. 江；河；水道；巨流
+road                           | [rəud]                               | n. 路，道路
+rob                            | [rɔb]                                | v. 抢夺，抢劫
+robot                          | [ˈrəubɔt]                            | n. 机器人
+rock                           | [rɔk]                                | n. 岩石,大石头 vt. 摇,摇晃
+room                           | [rum]                                | n. 房间,室;空间;地方
+rose                           | [rəuz]                               | n. 玫瑰花
+rough                          | [rʌf]                                | a. 粗糙的，粗略的
+round                          | [raund]                              | ad. 转过来 prep. 环绕一周，围着 a. 圆的；球形的
+row                            | [rəu]                                | n.（一）排,（一）行 v. 划船
+rubber                         | [ˈrʌbə(r)]                           | n. 橡胶；合成橡胶
+rubbish                        | [ˈrʌbiːʃ]                            | n. 垃圾；废物
+rude                           | [ruːd]                               | a. 无理的, 粗鲁的
+rule                           | [ruːl]                               | n. 规则,规定 vt. 统治,支配
+ruler                          | [ˈruːlə(r)]                          | n. 统治者；直尺
+run (ran, run)                 | [rʌn]                                | vi. 跑，奔跑；（颜色）褪色
+runner                         | [ˈrʌnə(r)]                           | n. 赛跑者；操作者；滑行装置
+rush                           | [rʌʃ]                                | vi. 冲，奔跑
+Russia                         | [ˈrʌʃə]                              | n. 俄罗斯，俄国
+Russian                        | [ˈrʌʃ(ə)n]                           | a. 俄国人的，俄语的 n. 俄国人，俄语
+sad                            | [sæd]                                | a.（使人）悲伤的
+safe                           | [seɪf]                               | a. 安全的 n. 保险柜
+safety                         | [ˈseɪftɪ]                            | n. 安全，保险
+sail                           | [seɪl]                               | n. 航行 v. 航行，开航
+salad                          | [ˈsæləd]                             | n. 色拉
+sale                           | [seɪl]                               | n. 卖，出售
+salesgirl                      | [ˈseɪlzɡɜːl]                         | n. 女售货员
+salesman                       | [ˈseɪlzmən]                          | n. 男售货员
+saleswoman                     | [seɪlzwʊmən]                         | n. 女售货员
+salt                           | [sɔːlt, sɔlt]                        | n. 盐
+same                           | [seɪm]                               | n. 同样的事 a. 同样的,同一
+sand                           | [sænd]                               | n. 沙，沙子
+sandwich                       | [ˈsænwɪdʒ]                           | n. 三明治（夹心面包片）
+satellite                      | [ˈsætəlaɪt]                          | n. 卫星
+satisfaction                   | [sætɪsˈfækʃ(ə)n]                     | n. 满意
+satisfy                        | [ˈsætɪsfaɪ]                          | vt. 满足，使满意
+Saturday                       | [ˈsætədɪ]                            | n. 星期六
+save                           | [seɪv]                               | vt. 救，挽救，节省
+say (said, said)               | [seɪ]                                | vt. 说，讲
+scenery                        | [ˈsiːnərɪ]                           | n. 风景，景色，风光
+school                         | [skuːl]                              | n. 学校
+schoolbag                      | ['sku:lbæg]                          | n. 书包
+schoolmate                     | [ˈskuːlmeɪt]                         | n. 同校同学
+science                        | [ˈsaɪəns]                            | n. 科学，自然科学
+scientific                     | [saɪənˈtɪfɪk]                        | a. 科学的
+scientist                      | [ˈsaɪəntɪst]                         | n. 科学家
+scissors                       | [ˈsɪzəz]                             | n. 剪刀，剪子
+score                          | [skɔː(r)]                            | n.& v. 得分，分数,二十
+screen                         | [skriːn]                             | n. 幕，荧光屏
+sea                            | [siː]                                | n. 海，海洋
+seagull                        | [ˈsiːɡʌl]                            | n. 海鸥
+search                         | [sɜːtʃ]                              | n.& v. 搜寻，搜查
+season                         | [ˈsiːz(ə)n]                          | n. 季；季节
+seat                           | [siːt]                               | n. 座位，座
+second                         | [ˈsekənd]                            | n. 秒 num. 第二 a. 第二的
+secondhand                     | ['sekənd'hænd]                       | n. 二手货; 旧货
+secret                         | [ˈsiːkrɪt]                           | n. 秘密，内情
+secretary                      | [ˈsekrətərɪ]                         | n. 秘书；书记
+see (saw, seen)                | [siː]                                | vt. 看见，看到；领会；拜会
+seem                           | [siːm]                               | v. 似乎，好像
+seldom                         | [ˈseldəm]                            | ad. 很少，不常
+sell (sold, sold)              | [sel]                                | v. 卖，售
+send (sent, sent)              | [send]                               | v. 打发，派遣；送，邮寄
+sentence                       | [ˈsent(ə)ns]                         | n. 句子
+separate                       | [ˈsepərət]                           | v. 使分开，使分离 a. 单独的，分开的
+September                      | [səpˈtembə(r)]                       | n. 9月
+serious                        | [ˈsɪərɪəs]                           | a. 严肃的,严重的,认真的
+servant                        | [ˈsɜːvənt]                           | n. 仆人，佣人
+serve                          | [sɜːv]                               | vt. 招待（顾客等）,服务
+set (set, set)                 | [set]                                | vt. 释放，安置 n. 装备，设备
+seven                          | [ˈsev(ə)n]                           | num. 七
+seventeen                      | [sevənˈtiːn]                         | num. 十七
+seventh                        | [ˈsevənθ]                            | num. 第七
+seventy                        | [ˈsevəntɪ]                           | num. 七十
+several                        | [ˈsevr(ə)l]                          | pron. 几个,数个 a. 若干
+severe                         | [sɪˈvɪə(r)]                          | a. 极为恶劣,十分严重的
+shall (should)                 | [ʃæl, ʃ(ə)l]                         | v. aux.（表示将来）将要，会；…好吗
+shape                          | [ʃeɪp]                               | n. 形状，外形 v. 使成型，制造，塑造
+share                          | [ʃeə(r)]                             | vt. 分享，共同使用
+sharp                          | [ʃɑːp]                               | a. 锋利的，尖的
+sharpen                        | [ˈʃɑːpən]                            | v.（使）变锐利，削尖
+sharpener                      | [ˈʃɑːpənə(r)]                        | n. 削尖用的器具
+she                            | [ʃiː]                                | pron. 她
+sheep (复sheep)                | [ʃiːp]                               | n.（绵）羊；羊皮；驯服者
+sheet                          | [ʃiːt]                               | n. 成幅的薄片，薄板
+shelf (复 shelves)             | [ʃelf]                               | n. 架子；搁板；格层；礁；陆架
+shine                          | [ʃaɪn]                               | n. 光泽；光彩；阳光；晴天；光(亮)
+shine (shone, shone或-d, -d)   | [ʃaɪn]                               | v. 发光；照耀；杰出；擦亮
+ship                           | [ʃɪp]                                | n. 船，轮船 vi. 用船装运
+shirt                          | [ʃɜːt]                               | n. 男衬衫
+shoe                           | [ʃuː]                                | n. 鞋
+shoot                          | [ʃuːt]                               | (shot, shot) vt. 射击，射中，发射
+shop                           | [ʃɔp]                                | vi. 买东西 n. 商店,车间
+shopping                       | [ˈʃɔpɪŋ]                             | n. 买东西
+shore                          | [ʃɔː(r)]                             | n. 滨，岸
+short                          | [ʃɔːt]                               | a. 短的；矮的
+shot                           | [ʃɔt]                                | n. 射击，开枪，开炮，射击声；子弹
+should                         | [ʃud]                                | v. mod. 应当，应该，会 v. aux. 会,应该（shall的过去时态）
+shout                          | [ˈʃaut]                              | n.& v. 喊，高声呼喊
+show                           | [ʃəʊ]                                | n. 展示,展览（会）;演出
+show                           | [ʃəʊ]                                | (showed, shown 或 showed)v. 给…看,出示,显示
+shower                         | [ˈʃaʊə(r)]                           | n. 阵雨；淋浴
+shut (shut, shut)              | [ʃʌt]                                | v. / n. 关上，封闭；禁闭；
+shy                            | [ʃaɪ]                                | a. 害羞的
+sick                           | [sɪk]                                | a. 有病,患病的,（想）呕吐
+side                           | [said]                               | n. 边，旁边，面，侧面
+sign                           | [sain]                               | n. 符号，标记
+silence                        | [ˈsailəns]                           | n. 安静，沉默
+silent                         | [ˈsailənt]                           | a. 无声的，无对话的
+silk                           | [silk]                               | n.（蚕）丝，丝织品
+silly                          | [ˈsili]                              | a. 傻的，愚蠢的
+simple                         | [ˈsimp(ə)l]                          | a. 简单的，简易的
+since                          | [sins]                               | ad. 从那时以来 conj. 从…以来，…以后，由于 prep. 从…以来
+sing (sang, sung)              | [siŋ]                                | v. 唱，唱歌
+singer                         | [siŋə]                               | n. 歌唱家，歌手
+single                         | [ˈsiŋɡ(ə)l]                          | a. 单一的，单个的
+sink (sank, sunk)              | [siŋk]                               | vi. 下沉；消沉n. 洗涤槽；污水槽
+sir                            | [səː (r)]                            | n. 先生；阁下
+sister                         | [ˈsistə(r)]                          | n. 姐；妹
+sit (sat, sat)                 | [sɪt]                                | vi. 坐
+situation                      | [sɪtjʊˈeɪʃ(ə)n]                      | n. 形势，情况
+six                            | [sɪks]                               | num. 六
+sixth                          | [sɪksθ]                              | num. 第六
+sixty                          | [ˈsɪkstɪ]                            | num. 六十
+sixteen                        | [ˈsɪkstiːn]                          | num. 十六
+sixteenth                      | [sɪksˈtiːnθ]                         | num. 第十六
+size                           | [saiz]                               | n. 尺寸，大小
+skate                          | [skeɪt]                              | vi. 溜冰，滑冰
+skateboard                     | [ˈskeɪtbɔːd]                         | n. 冰鞋，滑板
+ski                            | [skiː]                               | n.& vi. 滑雪板；滑雪
+skirt                          | [skɜːt]                              | n. 女裙
+sky                            | [skaɪ]                               | n. 天；天空
+sleep (slept, slept)           | [sliːp]                              | vi. 睡觉
+slow                           | [sləʊ]                               | ad. 慢慢地，缓慢地
+small                          | [smɔːl]                              | a. 小的，少的
+smell (smelt, smelt / -ed,-ed) | [smel]                               | v. 嗅，闻到；发气味 n. 气味
+smile                           | [smaɪl]                              | n.& v. 微笑
+smoke                           | [sməʊk]                              | n. 烟 v. 冒烟；吸烟
+smoking                         | [ˈsməʊkɪŋ]                           | n. 吸烟,抽烟;冒烟
+snake                           | [sneɪk]                              | n. 蛇 v. 蛇般爬行;蜿蜒行进
+snow                            | [snəʊ]                               | n. 雪 vi.下雪
+so                              | [səʊ]                                | ad. 如此，这么；非常；同样 conj. 因此，所以
+soap                            | [səʊp]                               | n. 肥皂
+society                         | [səˈsaɪətɪ]                          | n. 社会
+sock                            | [sɔk]                                | n. 短袜
+sofa                            | [səʊfə]                              | n.（长）沙发
+soft                            | [sɔft; (US) sɔːft]                   | a. 软的，柔和的
+soil                            | [sɔɪl]                               | n. 土壤，土地
+soldier                         | [ˈsəʊldʒə(r)]                        | n. 士兵，战士
+some                            | [sʌm]                                | a. 一些，若干；有些；某一 pron. 若干，一些
+somebody                        | [ˈsʌmbɔdɪ]                           | pron. 某人；有人；有名气的人
+someone                         | [ˈsʌmwʌn]                            | pron. 某一个人
+something                       | [ˈsʌmθɪŋ]                            | pron. 某事；某物
+sometimes                       | [ˈsʌmtaɪmz]                          | ad. 有时
+somewhere                       | [ˈsʌmweə]                            | ad. 在某处
+son                             | [sʌn]                                | n. 儿子
+song                            | [sɔŋ]                                | n. 歌唱；歌曲
+soon                            | [suːn]                               | ad. 不久,很快,一会儿
+sorry                           | [ˈsɔrɪ]                              | a. 对不起,抱歉;难过的
+so-so                           | [səʊ-səʊ]                            | a. 一般；不怎么样；凑合
+sound                           | [saʊnd]                              | vi. 听起来,发出声音 n. 声音
+soup                            | [suːp]                               | n. 汤
+sour                            | [ˈsauə(r)]                           | a. 酸的，馊的
+south                           | [ˈsauθ]                              | a. 南(方)的 ad. 在南方；向南方 n. 南；南方；南部
+southeast                       | [‚sauθ'iːst]                         | n. 东南
+southern                        | ['sʌð(ə)n]                           | a. 南部的，南方的
+southwest                       | [sauθ'west]                          | n. 西南
+sow (sowed, sown或-ed)          | [səu]                                | vt. 播种
+space                           | [speɪs]                              | n. 空间
+spaceship                       | [ˈspeɪsʃɪp]                          | n. 宇宙飞船
+Spanish                         | [ˈspænɪʃ]                            | a. 西班牙人的，西班牙的，西班牙语的 n. 西班牙语
+speak (spoke, spoken)           | [ˈspiːk]                             | v. 说，讲；谈话；发言
+special                         | [ˈspeʃ(ə)l]                          | a. 特别的，专门的
+speech                          | [spiːtʃ]                             | n. 演讲
+speed                           | [spiːd]                              | n. 速度 v.（使）加速
+spell                           | [spel]                               | vt. 拼写
+spirit                          | [ˈspɪrɪt]                            | n. 精神
+spit                            | [spɪt]                               | v. 吐唾沫；吐痰
+splendid                        | [ˈsplendɪd]                          | a. 灿烂的，辉煌的；（口语）极好的
+spoon                           | [spuːn]                              | n. 匙, 调羹
+sport                           | [spɔːt]                              | n. 体育运动，锻炼；(复，英)运动会
+spot                            | [spɔt]                               | n. 斑点，污点；场所，地点 v. 沾上污渍，弄脏
+spring                          | [sprɪŋ]                              | n. 春天,春季 n. 泉水,泉
+square                          | [skweə(r)]                           | n. 广场 a. 平方的；方形的，宽而结实的（体格，肩膀）
+stamp                           | [stæmp]                              | n. 邮票
+stand                           | [stænd]                              | n. 站；立；停止；立场；地位；台；坛；摊
+stand (stood, stood)            | [stænd]                              | v. 站；立；起立；坐落；经受；持久
+star                            | [stɑː(r)]                            | n. 星，恒星
+start                           | [stɑːt]                              | v. 开始，着手；出发
+state                           | [steɪt]                              | n. 状态；情形；国家，（美国的）州
+station                         | [ˈsteɪʃ(ə)n]                         | n. 站，所，车站；电台
+stay                            | [steɪ]                               | n.& vi. 停留，逗留，呆
+steal (stole, stolen)           | [stiːl]                              | vt. 偷, 窃取
+steep                           | [stiːp]                              | a. 险峻的；陡峭的
+step                            | [step]                               | n. 脚步,台阶,梯级 vi. 走,跨步
+stick (stuck, stuck)            | [stɪk]                               | vi. 粘住，钉住；坚持 n. 木棒（棍）,枝条
+still                           | [stɪl]                               | a. 不动的,平静的 ad. 仍然,还
+stocking                        | [ˈstɔkɪŋ]                            | n. 长统袜
+stomach                         | [ˈstʌmək]                            | n. 胃，胃部
+stomachache                     | [ˈstʌməkeɪk]                         | n. 胃疼
+stone                           | [stəʊn]                              | n. 石头，石料
+stop                            | [stɔp]                               | n. 停；（停车）站 v. 停，停止，阻止
+store                           | [stɔː(r)]                            | n. 商店 vt. 储藏，存储
+storm                           | [stɔːm]                              | n. 风暴，暴（风）雨
+story                           | [ˈstɔːrɪ]                            | n. 故事，小说
+straight                        | [streɪt]                             | a. 一直的，直的 ad. 一直地，直地
+strange                         | [streɪndʒ]                           | a. 奇怪,奇特的,陌生的
+street                          | [striːt]                             | n. 街，街道
+strict                          | [strɪkt]                             | a. 严格的，严密的
+strike (struck, struck或stricken) | [straɪk]                             | v.（钟）鸣;敲（响）,罢工,擦（打）火, 侵袭
+strong                          | [strɔŋ]                              | a. 强(壮)的；坚固的；强烈的；坚强的
+student                         | [ˈstjuːdənt]                         | n. 学生
+study                           | [ˈstʌdɪ]                             | v. 学习；研究 n. 书房
+stupid                          | [ˈstjuːpɪd]                          | a. 愚蠢的，笨的
+subject                         | [ˈsʌbdʒɪkt]                          | n. 题目；主题；学科；主语；主体
+succeed                         | [səkˈsiːd]                           | vi. 成功
+success                         | [səkˈses]                            | n. 成功
+successful                      | [səkˈsesfʊl]                         | a. 成功的,有成就的
+such                            | [sʌtʃ]                               | ad. 那么 pron.（泛指）人，事物 a. 这样的，那样的
+sudden                          | [ˈsʌd(ə)n]                           | a. 突然的
+sugar                           | [ˈʃʊɡə(r)]                           | n. 糖
+suggest                         | [səˈdʒest; (US) sə ˈdʒest]           | vt. 建议，提议
+suggestion                      | [səˈdʒestʃ(ə)n]                      | n. 建议
+suit                            | [suːt, sjuːt]                        | vt. 适合 n. 一套（衣服）
+summer                          | [ˈsʌmə(r)]                           | n. 夏天，夏季
+sun                             | [sʌn]                                | n. 太阳，阳光
+Sunday                          | [ˈsʌndeɪ]                            | n. 星期日
+sunglasses                      | [ˈsʌnɡlɑːsɪs]                        | n. 太阳眼镜，墨镜
+sunlight                        | [ˈsʌnlaɪt]                           | n. 日光，阳光
+sunny                           | [ˈsʌnɪ]                              | a. 晴朗的;阳光充足的
+sunrise                         | [ˈsʌnraɪs]                           | n. 黎明，拂晓
+sunset                          | [ˈsʌnset]                            | n. 日落(时分)
+sunshine                        | [ˈsʌnʃaɪn]                           | n. 阳光
+super                           | [ˈsuːpə(r), ˈsjuːpə(r)]              | a. 顶好的，超级的
+supermarket                     | [ˈsuːpəmɑːkɪt]                       | n. 超级市场
+supper                          | [ˈsʌpə(r)]                           | n. 晚餐，晚饭
+supply                          | [səˈplaɪ]                            | vt.& n. 供给，供应
+suppose                         | [səˈpəʊz]                            | vt. 猜想,假定,料想
+sure                            | [ʃʊə(r), ʃɔː(r)]                     | a. 确信，肯定 ad. (口语)的确，一定，当然
+surf                            | [ˈsɜːf]                              | v. 冲浪
+surprise                        | [səˈpraɪz]                           | vt. 使惊奇,使诧异 n. 惊奇,诧异
+sweater                         | [ˈswetə(r)]                          | n. 厚运动衫，毛衣
+sweep(swept,swept)              | [swiːp]                              | v. 扫除，扫
+sweet                           | [swiːt]                              | n. 甜食;蜜饯;甜点;糖果;芳香 a. 甜的;可爱的;亲切的
+swim (swam, swum)               | [swɪm]                               | vi. 游泳,游 n. 游泳，游
+swimming                        | [ˈswɪmɪŋ]                            | n. 游泳
+swimming pool                   | [ˈswɪmɪŋ puːl]                       | n. 游泳池
+swing                           | [swɪŋ]                               | vt. 挥舞，摆动 n. 秋千
+table                           | [ˈteɪb(ə)l]                          | n. 桌子，表格
+tail                            | [teɪl]                               | n. (动物的)尾巴
+tailor                          | [ˈteɪlə(r)]                          | n. 裁缝
+take (took, taken)              | [teɪk]                               | vt. 拿；拿走；做；服用；乘坐；花费
+tale                            | [teɪl]                               | n. 故事, 传说
+talk                            | [tɔːk]                               | n.& v. 谈话,讲话,演讲,交谈
+tall                            | [tɔːl]                               | a. 高的
+tape                            | [teɪp]                               | n. 磁带；录音带
+task                            | [tɑːsk; (US) tæsk]                   | n. 任务, 工作
+taste                           | [teɪst]                              | n. 品尝, 尝味；味道 vt. 品尝, 尝味
+taxi                            | [ˈtæksɪ]                             | n. 出租汽车
+tea                             | [tiː]                                | n. 茶；茶叶 
+teach(taught,taught)            | [tiː tʃ]                             | v. 教书,教
+teacher                         | [ˈtiːtʃə(r)]                         | n. 教师，教员
+team                            | [tiːm]                               | n. 队，组
+teamwork                        | [ˈtiːmwəːk]                          | n. 合作，协同工作
+teapot                          | [ˈtiːpɔt]                            | n. 茶壶
+tear                            | [teə(r)]                             | n. 眼泪 v. 扯破, 撕开
+technology                      | [tekˈnɔlədʒɪ]                        | n. 技术
+teenager                        | [ˈtiːneɪdʒə(r)]                      | n.（13～19岁的）青少年，十几岁的少年
+telegram                        | [ˈtelɪɡræm]                          | n. 电报
+telegraph                       | [ˈtelɪɡrɑːf; (US) -ɡræf]             | v. (拍) 电报
+telephone                       | [ˈtelɪfəun]                          | v. 打电话 n. 电话
+television                      | [ˈtelɪviʒən]                         | n. 电视
+tell (told, told)               | [tel]                                | vt. 告诉,讲述,吩咐
+temperature                     | [ˈtemprɪtʃə(r)]                      | n. 温度
+ten                             | [ten]                                | num. 十
+tent                            | [tent]                               | n. 帐篷
+term                            | [tɜːm]                               | n. 学期;术语;条款;项
+terrible                        | [ˈterɪb(ə)l]                         | a. 可怕的；糟糕的
+terrify                         | [ˈterɪfaɪ]                           | vt. 使人感到恐怖
+test                            | [test]                               | vt.& n. 测试, 考查，试验
+text                            | [tekst]                              | n. 文本，课文
+textbook                        | [ˈtekstbʊk]                          | n. 课本，教科书
+than                            | [ðen, ðæn]                           | conj. 比
+thank                           | [θæŋk]                               | vt. 感谢，致谢，道谢 n.（复）感谢，谢意
+thankful                        | [ˈθæŋkfʊl]                           | a. 感谢的，感激的
+that                            | [ðæt]                                | a.& pron.那，那个 conj. 那，那个 ad. 那么，那样
+the                             | [ðə, ðɪ, ðiː]                        | art. 这（那）个,这（那）些
+theatre (美theater)             | ['θiətə]                             | n. 剧场，戏院
+their                           | [ðeə(r)]                             | pron. 他(她,它)们的
+theirs                          | [ðeəz]                               | pron. 他（她,它）们的
+them                            | [ð(ə)m, ðem]                         | pron. 他/她/它们（宾格）
+themselves                      | [ðəmˈselvz]                          | pron. 他/她/它们自己
+then                            | [ðen]                                | ad. 当时,那时,然后,那么
+there                           | [ðeə(r)]                             | int. 那!你瞧! n. 那里,那儿 ad. 在那里,往那里
+these                           | [ðiːz]                               | a. & pron. 这些
+they                            | [ðeɪ]                                | pron. 他（她）们；它们
+thick                           | [θɪk]                                | a. 厚的
+thief (复thieves)               | [θiːf]                               | n. 窃贼, 小偷
+thin                            | [θɪn]                                | a. 薄的；瘦的；稀的
+thing                           | [θɪŋ]                                | n. 东西；(复)物品，用品；事情，事件
+think (thought, thought)        | [θɪŋk]                               | v. 想；认为；考虑
+third                           | [θəːd]                               | num. 第三
+thirst                          | [θəːst]                              | n. 渴；口渴
+thirsty                         | [ˈθəːstɪ]                            | a. 渴
+thirteen                        | [θəːtiːn]                            | num. 十三
+thirty                          | [ˈθəːtɪ]                             | num. 三十
+this                            | [ðɪs]                                | a.& pron.这，这个
+those                           | [ðəʊz]                               | a.& pron. 那些
+though                          | [ðəʊ]                                | conj. 虽然，可是
+thought                         | [θɔːt]                               | n. 思考,思想;念头
+thousand                        | [ˈθaʊzənd]                           | num. 千
+three                           | [θriː]                               | num. 三
+through                         | [θruː]                               | prep. 穿（通）过;从始至终 ad. 穿(通)过;自始至终,全部
+throw(threw,thrown)             | [θrəʊ]                               | v. 投,掷,扔
+Thursday                        | [ˈθəːzdeɪ]                           | n. 星期四
+thus                            | [ðʌs]                                | ad. 这样；因而
+tick                            | [tɪk]                                | vt. 作记号 n. 记号,符号,滴答声
+ticket                          | [ˈtɪkɪt]                             | n. 票；卷
+tidy                            | [ˈtaidi]                             | a. 整洁的，干净的 vt. 弄整洁，弄干净
+tie                             | [taɪ]                                | vt.（用绳，线）系，拴，扎 n. 领带，绳子，结；关系
+tiger                           | [ˈtaɪɡə(r)]                          | n. 老虎
+till                            | [tɪl]                                | conj.& prep. 直到,直到…为止
+time                            | [taɪm]                               | n. 时间;时期;钟点,次,回 vt. 测定…的时间,记录…的时间
+tire                            | [ˈtaɪə(r)]                           | vi. 使疲劳
+tired                           | [ˈtaɪəd]                             | a. 疲劳的，累的
+to                              | [tʊ, tuː]                            | prep. 给；对，向，到
+today                           | [tədei]                              | ad.& n. 今天;现在,当前
+together                        | [təˈgeðə]                            | ad. 一起，共同
+toilet                          | [ˈtɔɪlɪt]                            | n. 厕所
+Tokyo                           | [ˈtəʊkjəʊ]                           | n. 东京
+tomato                          | [təˈmɑːtəʊ; (US) təˈmeɪtəʊ]          | n. 西红柿，番茄
+tomb                            | [tuːm]                               | n. 坟墓
+tomorrow                        | [təˈmɔrəʊ]                           | ad. & n. 明天
+ton                             | [tʌn]                                | n.（重量单位）吨
+tongue                          | [tʌŋ]                                | n. 舌，舌头
+tonight                         | [təˈnaɪt]                            | ad.& n. 今晚，今夜
+too                             | [tuː]                                | ad. 也,还,又,太,非常
+tool                            | [tuːl]                               | n. 工具，器具
+tooth (复 teeth)                | [tuːθ]                               | n. 牙齿
+toothache                       | [ˈtuːθeɪk]                           | n. 牙痛
+toothbrush                      | [ˈtuːθbrʌʃ]                          | n. 牙刷
+toothpaste                      | [ˈtuːθpeɪst]                         | n. 牙膏
+top                             | [tɔp]                                | n. 顶部,（物体的）上面
+total                           | [ˈtəʊt(ə)l]                          | a. 总数的;完全的 n./ v. 合计,总计
+touch                           | [tʌtʃ]                               | vt. 触摸，接触
+tough                           | [tʌf ]                               | a. 坚硬的；结实的；棘手的，难解的
+tour                            | [tʊə(r)]                             | n. 参观, 观光, 旅行
+tourism                         | [ˈtʊərɪz(ə)m]                        | n. 旅游业；观光
+tourist                         | [ˈtʊərɪst]                           | vn. 旅行者，观光者
+toward(s)                       | [təˈwɔːd(z)]                         | prep. 向，朝，对于
+towel                           | [ˈtaʊəl]                             | n. 毛巾
+tower                           | [ˈtaʊə(r)]                           | n. 塔
+town                            | [taʊn]                               | n. 城镇，城
+toy                             | [tɔɪ]                                | n. 玩具, 玩物
+track                           | [træk]                               | n. 轨道；田径
+tractor                         | [ˈtræktə(r)]                         | n. 拖拉机
+trade                           | [treɪd]                              | n. 商业,贸易 vt. 交易
+tradition                       | [trəˈdɪʃ (ə)n]                       | n. 传统，风俗
+traditional                     | [trəˈdɪʃ(ə)n(ə)l]                    | a. 传统的，风俗的，惯例的
+traffic                         | [ˈtræfɪk]                            | n. 交通，来往车辆
+train                           | [treɪn]                              | n. 火车 v. 培训,训练
+trainer                         | [treɪnə(r)]                          | n. 训练人；教练
+training                        | [ˈtreɪnɪŋ]                           | n. 培训
+translate                       | [trænsˈleɪt]                         | vt. 翻译
+trap                            | [træp]                               | n. 陷阱 vt. 使陷入困境
+travel                          | [ˈtræv(ə)l]                          | n.& vi. 旅行
+traveler                        | [ˈtrævələ(r)]                        | n. 旅行者
+treat                           | [triːt]                              | vt. 对待，看待
+tree                            | [triː]                               | n. 树
+trip                            | [trɪp]                               | n. 旅行，旅程
+trouble                         | [ˈtrʌb(ə)l]                          | vt. 使苦恼,使忧虑,使麻烦 n. 问题,疾病,烦恼,麻烦
+trousers                        | [ˈtraʊzəz]                           | n. 裤子，长裤
+truck                           | [trʌk]                               | n. 卡车, 运货车；车皮
+true                            | [truː]                               | a. 真的，真实的；忠诚的
+truth                           | [truːθ]                              | n. 真理,事实,真相,实际
+try                             | [trai]                               | v. 试，试图，努力
+T-shirt                         | [tiː-ʃɜːt]                           | n. T恤衫
+Tuesday                         | [ˈtjuːzdeɪ]                          | n. 星期二
+turkey                          | [ˈtɜːkɪ]                             | n. 火鸡
+turn                            | [tɜːn]                               | v. 旋转，翻转，转变，转弯 n. 轮流，顺序
+turning                         | [ˈtɜːnɪŋ]                            | n. 拐弯处，拐角处
+TV(缩) = television             | [tiː'viː]                            | n. 电视机
+twelfth                         | [twelfθ]                             | num. 第十二
+twelve                          | [twelv]                              | num. 十二
+twentieth                       | [ˈtwentɪɪθ]                          | vnum. 第二十
+twenty                          | [ˈtwentɪ]                            | num. 二十
+twenty-first                    | [ˈtwentɪ-fɜːst]                      | num. 第二十一
+twenty-one                      | [ˈtwentɪ- wʌn]                       | num. 二十一
+twice                           | [twaɪs]                              | ad. 两次；两倍
+twin                            | [twɪn]                               | n. 双胞胎之一
+two                             | [tuː]                                | num. 二
+type                            | [ˈtaɪp]                              | vt. 打字 n. 种类,类型
+typical                         | [taɪpɪkəl]                           | adj,典型的，有代表性的
+umbrella                        | [ʌmˈbrelə]                           | n. 雨伞
+U.N./ UN(缩) = the United Nations | [juː ˈən]                          | n. 联合国
+uncle                           | [ˈʌŋk(ə)l]                           | n. 叔,伯,舅,姑夫,姨父
+under                           | [ˈʌndə(r)]                           | ad.& prep. 在…下面，向…下面
+underground                     | [ʌndəˈɡraʊnd]                        | a. 地下的 n. 地铁
+understand (understood, understood)| [ʌndəˈstænd]                      | v. 懂得;明白;理解
+understanding                   | [ʌndəˈstændɪŋ]                       | n. 领会;理解
+unfair                          | [ʌnˈfeə(r)]                          | a. 不公平的，不公正的
+unit                            | [ˈjuːnɪt]                            | n. 单元，单位
+universe                        | [ˈjuːnɪvɜːs]                         | n. 宇宙
+university                      | [juːnɪˈvɜːsɪtɪ]                      | n. 大学
+unknown                         | [ʌnnəun]                             | a. 不知道的
+unless                          | [ʌnˈles]                             | conj. 如果不，除非
+unlike                          | [ʌnˈlaɪk]                            | prep. 不像，和…不同
+until                           | [ʌnˈtɪl]                             | prep.& conj. 直到…为止
+unusual                         | [ʌnˈjuːʒuəl]                         | a. 不平常的，异常的
+up                              | [ʌp]                                 | ad. 向上;在上方 prep. 向(高处);向(在)…上(面)游
+upon                            | [əˈpɔn]                              | prep. 在…上面
+upstairs                        | [ʌpˈsteəz]                           | ad. 在楼上，到楼上
+U.S.A./USA(缩) = the United States of America |                        | 美国（美利坚合众国）
+use                             | [juːz]                               | vt. 利用,使用,应用 n. [juːs] 用法,应用,运用
+used                            | [juːzd]                              | a. 用过的;旧的;二手的
+useful                          | [ˈjuːsful]                           | a. 有用的，有益的
+useless                         | [ˈjuːslɪs]                           | a. 无用的
+user                            | [ˈjuːzə]                             | n. 使用者；用户
+usual                           | [ˈjuːʒʊəl]                           | a. 通常的，平常的
+usually                         | [ˈjuːʒʊəlɪ]                          | ad. 通常，经常
+valley                          | [ˈvælɪ]                              | n. 山谷, 溪谷
+VCD = versatile compact disk    |                                      | n. 影碟光盘
+vegetable                       | [ˈvedʒɪtəb(ə)l]                      | n. 蔬菜
+very                            | [ˈverɪ]                              | ad. 很，非常
+victim                          | [ˈvɪktɪm]                            | n. 受害者，牺牲品
+video                           | [ˈvɪdɪəʊ]                            | n. 录像，视频
+village                         | [ˈvɪlɪdʒ]                            | n. 村庄，乡村
+villager                        | ['vilidʒə]                           | n. 村民
+violin                          | [vaɪəˈlɪn]                           | n. 小提琴
+visit                           | [ˈvizit]                             | n.& vt. 参观，访问，拜访
+visitor                         | [ˈvɪzɪtə(r)]                         | n. 访问者，参观者
+voice                           | [vɔɪs]                               | n. 说话声; 语态
+volleyball                      | [vɔlibɔːl]                           | n. 排球
+volunteer                       | [valən’tɪə]                          | n.志愿者 v. 自愿做某事
+wait                            | [weɪt]                               | vi. 等，等候
+wake (woke, woken)              | [weɪk]                               | v. 醒来,叫醒
+walk                            | [wɔːk]                               | n.& v. 步行；散步
+wallet                          | [ˈwɔlɪt]                             | n. (放钱,证件等的)皮夹
+want                            | [wɔnt]                               | vt. 想,想要,需要,必要
+war                             | [wɔː(r)]                             | n. 战争
+warm                            | [wɔːm]                               | a. 暖和的,温暖的;热情的
+warning                         | [ˈwɔːnɪŋ]                            | n. 警报
+washroom                        | [ˈwɔʃrʊm]                            | n. 盥洗室
+waste                           | [weɪst]                              | n.& vt. 浪费
+watch                           | [wɔtʃ]                               | vt. 观看，注视；当心，注意 n. 手表，表
+water                           | [ˈwɔːtə(r)]                          | n. 水v. 浇水
+wave                            | [weɪv]                               | n.（热、光、声等的）波，波浪 v. 挥手，挥动，波动
+way                             | [weɪ]                                | n. 路，路线；方式，手段
+we                              | [wiː, wɪ]                            | pron. 我们
+weak                            | [wiːk]                               | a. 差的，弱的，淡的
+wear (wore, worn)               | [weə(r)]                             | v. 穿，戴
+weather                         | [weðə(r)]                            | n. 天气
+Wednesday                       | [ˈwenzdeɪ]                           | n. 星期三
+week                            | [wiːk]                               | n. 星期，周
+weekday                         | [ˈwiːkdeɪ]                           | n. 平日,工作日
+weekend                         | [wiːkˈend, ˈwiːkend]                 | n. 周末
+weigh                           | [weɪ]                                | vt. 称…的重量，重（若干）
+weight                          | [weɪt]                               | n. 重，重量
+welcome                         | [ˈwelkəm]                            | int.n. & v. 欢迎 a. 受欢迎的
+well                            | [wel]                                | (better, best) ad. 好 a.好的,健康的 int. 好吧,那么,哎呀 n. 井
+well-known                      | [wel- nəʊn]                          | a. 出名,众所周知的
+west                            | [west]                               | a. (在)西；向西,从西来的 ad. 在西方,向西方 n. 西部；西方
+western                         | [ˈwest(ə)n]                          | a. 西方的，西部的
+westerner                       | ['westənə]                           | n. 西方人
+westwards                       | [ˈwestwədz]                          | ad. 向西
+wet                             | [wet]                                | a. 湿的,潮的,多雨的
+what                            | [wɔt; (US) hwɑt]                     | pron. 什么,怎么样 a. 多么，何等；什么
+whatever                        | [wɔtˈevə(r)]                         | conj. & pron. 无论什么，不管什么
+wheat                           | [wiːt; (US) hwiːt]                   | n. 小麦
+wheel                           | [wiːl; (US) hwiːl]                   | n. 轮，机轮
+when                            | [wen]                                | conj. 当…的时候 ad. 什么时候，何时
+whenever                        | [wenˈevə(r)]                         | conj. 每当，无论何时
+where                           | [weə(r); (US) hweər]                 | ad. 在哪里；往哪里
+wherever                        | [weərˈevə(r)]                        | conj. 无论在哪里
+whether                         | [ˈweðə(r); (US) ˈhweðər]             | conj. 是否
+which                           | [wɪtʃ; (US) hwɪtʃ]                   | pron. 哪一个；哪些
+whichever                       | [wɪtʃˈevə(r)]                        | pron. 无论哪个;无论哪些
+while                           | [waɪl; (US) hwaɪl]                   | conj. 在…的时候,和…同时 n. 一会儿，一段时间
+white                           | [waɪt; (US) hwaɪt]                   | a. 白色的 n. 白色
+who                             | [huː]                                | pron. 谁
+whole                           | [həʊl]                               | a. 整个的
+whom                            | [huːm]                               | pron. (who的宾格 )
+whose                           | [huːz]                               | pron. 谁的
+why                             | [waɪ; (US) hwaɪ]                     | ad./ int. 为什么, 你难道不知道（表示反驳、不耐烦等）
+wide                            | [waid]                               | a. 宽阔的
+wife                            | [waɪf]                               | n. 妻子
+will                            | [wɪl]                                | n. 意志, 遗嘱
+will (would)                    | [wɪl]                                | v. 将,会(表示将来)；愿意，要
+win (won, won)                  | [wɪn]                                | n. 获胜，赢得 
+wind (wound,wound)              | [wɪnd]                               | vt. 缠，连带；蜿蜒，弯曲 n. 风
+window                          | [ˈwɪndəʊ]                            | n. 窗户；计算机的窗
+windy                           | [ˈwɪndɪ]                             | a. 有风的，多风的
+wine                            | [waɪn]                               | n. 酒
+winner                          | [ˈwɪnə(r)]                           | n. 获胜者
+winter                          | [ˈwɪntə(r)]                          | n. 冬天，冬季
+wish                            | [wɪʃ]                                | n. 愿望，祝愿 vt. 希望，想要，祝愿
+with                            | [wɪð]                                | prep.关于,带有,以,和,用,有
+without                         | [wɪðaʊt]                             | prep. 没有
+wolf（复wolves）                 | [wʊlf]                               | n. 狼
+woman (复women)                 | [ˈwʊmən]                             | n. 妇女，女人
+wonder                          | [ˈwʌndə(r)]                          | v. 对…疑惑，感到惊奇,想知道 n. 惊讶,惊叹;奇迹
+wonderful                       | [ˈwʌndəfʊl]                          | a. 美妙的，精彩的；了不起的；太好了
+wood                            | [wud]                                | n.木头,木材,(复)树木,森林
+wool                            | [wul]                                | l n. 羊毛，羊绒
+woolen                          | ['wulin]                             | a. 羊毛的，羊毛制的
+word                            | [wəːd]                               | n. 词，单词；话
+work                            | [wəːk]                               | n. 工作,劳动,事情 vi. 工作;(机器、器官等)运转,活动
+worker                          | [wəːkə(r)]                           | n. 工人；工作者
+workplace                       | [wəːkpleɪs]                          | n. 工作场所，车间
+works                           | [wəːks]                              | n. 著作，作品
+world                           | [wəːld]                              | n. 世界
+worm                            | [wəːm]                               | n. 软体虫,蠕虫(尤指蚯蚓)
+worried                         | ['wʌrɪd]                             | a. 担心的，烦恼的
+worry                           | [wʌrɪ]                               | n.& v. 烦恼,担忧,发怒,困扰
+worse                           | [wə:s]                               | a. (bad的比较级)更坏的
+worst                           | [wə:st]                              | a. (bad的最高级)最坏的
+worth                           | [wə:θ]                               | a. 有…的价值,值得…的
+would                           | [wəd, wud]                           | modal v.（will的过去时）将会,打算,想要,过去常常
+wound                           | [wu:nd]                              | vt.伤,伤害 n. 创伤,伤口
+wounded                         | [wu:ndɪd]                            | a. 受伤的
+write                           | [raɪt]                               | (wrote, written) v. 写，书写；写作，著述
+wrong                           | [rɔŋ]                                | a. 错误,不正常,有毛病的
+X-ray                           | [eks-reɪ]                            | n. X射线；X光
+yard                            | [jɑːd]                               | n. 码；院子；场地
+year                            | [jɪə(r), jəː(r)]                     | n. 年
+yellow                          | [ˈjeləʊ]                             | a. 黄色的
+yes                             | [jes]                                | ad. 是，好，同意
+yesterday                       | [ˈjestədeɪ]                          | n.& ad. 昨天
+yet                             | [jet]                                | ad. 尚，还，仍然
+you                             | [juː, jʊ]                            | pron. 你；你们
+young                           | [jʌŋ]                                | a. 年轻的
+your                            | [jɔː]                                | pron. 你的；你们的
+yours                           | [jɔːz, jʊəz]                         | pron. 你的；你们的
+yourself                        | [jɔːˈself; (US) jʊərˈself]           | pron. 你自己
+yourselves                      | [jɔːˈselvz; (US) jʊərˈselvz]         | pron. 你们自己
+youth                           | [juːθ]                               | n. 青春；青年
+zero                            | [ˈzɪərəʊ]                            | n. & num. 零,零度,零点
+zoo                             | [zuː]                                | n. 动物园


### PR DESCRIPTION
将《中考英语词汇表.txt》转换了markdown 格式文档：可读性好一些，方便github展示，方便以表格形式打印或导出pdf。